### PR TITLE
migrate CLI tools from brew to mise

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -2,3 +2,16 @@
 node = "22"
 python = "3"
 uv = "latest"
+
+# CLI tools (migrated from brew)
+bat = "0.26.1"
+delta = "0.18.2"
+eza = "0.23.4"
+fzf = "0.67.0"
+gitui = "0.28.0"
+neovim = "0.11.5"
+ripgrep = "15.1.0"
+starship = "1.24.2"
+zellij = "0.43.1"
+zola = "0.22.0"
+zoxide = "0.9.8"

--- a/setup.sh
+++ b/setup.sh
@@ -21,18 +21,7 @@ fi
 exists=$(brew list)
 for f (
   mise
-  zellij
-  fzf
-  ripgrep
-  eza
-  zoxide
-  git-delta
-  gitui
-  bat
   procs
-  starship
-  zola
-  neovim
   arc
   wezterm
   font-hack-nerd-font


### PR DESCRIPTION
## Summary
- Move 11 CLI tools from brew to mise for better version management
- Tools migrated: bat, delta, eza, fzf, gitui, neovim, ripgrep, starship, zellij, zola, zoxide
- Keep brew for: mise itself, procs (not in mise registry), GUI apps, and fonts

## Test plan
- [x] Run `mise install` to install tools
- [x] Run `brew uninstall` to remove old brew versions
- [x] Verify tools work with `mise list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)