### PR TITLE
migrate fbr command to mise task

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -35,11 +35,5 @@ eval "$(zoxide init zsh)"
 # starship
 eval "$(starship init zsh)"
 
-# fbr - checkout git branch (including remote branches)
-fbr() {
-  local branches branch
-  branches=$(git branch --all | grep -v HEAD) &&
-  branch=$(echo "$branches" |
-           fzf-tmux -d $(( 2 + $(wc -l <<< "$branches") )) +m) &&
-  git checkout $(echo "$branch" | sed "s/.* //" | sed "s#remotes/[^/]*/##")
-}
+# fbr - checkout git branch (using mise task)
+alias fbr='mise run fbr'

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -15,3 +15,6 @@ starship = "1.24.2"
 zellij = "0.43.1"
 zola = "0.22.0"
 zoxide = "0.9.8"
+
+[task_config]
+dir = "{{ config_root }}/tasks"

--- a/mise/tasks/fbr
+++ b/mise/tasks/fbr
@@ -1,0 +1,8 @@
+#!/bin/bash
+#MISE description="checkout git branch (including remote branches)"
+
+branches=$(git branch --all | grep -v HEAD)
+branch=$(echo "$branches" | fzf --height 40% --reverse +m)
+if [ -n "$branch" ]; then
+  git checkout $(echo "$branch" | sed "s/.* //" | sed "s#remotes/[^/]*/##")
+fi


### PR DESCRIPTION
## Summary
- Move `fbr` (git branch checkout with fzf) function from `.zshrc` to a file-based mise task
- Add `[task_config]` to `mise/config.toml` to specify tasks directory
- Replace shell function with alias to `mise run fbr`

## Test plan
- [ ] Run `mise run fbr` to verify task is recognized
- [ ] Run `fbr` alias to verify branch switching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)