### PR TITLE
fix fbr task to work from any directory

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -36,4 +36,4 @@ eval "$(zoxide init zsh)"
 eval "$(starship init zsh)"
 
 # fbr - checkout git branch (using mise task)
-alias fbr='mise run --cd ~/.config/mise fbr'
+alias fbr='mise run fbr'

--- a/mise/tasks/fbr
+++ b/mise/tasks/fbr
@@ -1,5 +1,6 @@
 #!/bin/bash
 #MISE description="checkout git branch (including remote branches)"
+#MISE dir="{{cwd}}"
 
 branches=$(git branch --all | grep -v HEAD)
 branch=$(echo "$branches" | fzf --height 40% --reverse +m)


### PR DESCRIPTION
## Summary
- Add `#MISE dir="{{cwd}}"` directive to fbr task to run in caller's working directory
- Revert `--cd` flag from .zshrc alias (no longer needed)

## Test plan
- [ ] Run `fbr` from a git repository other than dotfiles
- [ ] Verify branch selection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)