### PR TITLE
migrate shell aliases from .zshrc to mise

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,31 +1,11 @@
-# alias
-alias vi='nvim'
-
 # brew
 eval $(/opt/homebrew/bin/brew shellenv)
 
 # mise
 eval "$(mise activate zsh)"
 
-# exa
-if [[ $(command -v eza) ]]; then
-  alias e='eza --icons'
-  alias ls=e
-  alias ea='eza -a --icons'
-  alias la=ea
-  alias ee='eza -aal --icons -hl --git'
-  alias ll=ee
-  alias et='eza -T -L 3 -a -I "node_modules|.git|.cache" --icons'
-  alias lt=et
-  alias eta='eza -T -a -I "node_modules|.git|.cache" --color=always --icons | less -r'
-  alias lta=eta
-fi
-
 # zoxide
 eval "$(zoxide init zsh)"
 
 # starship
 eval "$(starship init zsh)"
-
-# fbr - checkout git branch (using mise task)
-alias fbr='mise run fbr'

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -22,5 +22,19 @@ zellij = "0.43.1"
 zola = "0.22.0"
 zoxide = "0.9.8"
 
+[shell_alias]
+vi = "nvim"
+e = "eza --icons"
+ls = "eza --icons"
+ea = "eza -a --icons"
+la = "eza -a --icons"
+ee = "eza -aal --icons -hl --git"
+ll = "eza -aal --icons -hl --git"
+et = "eza -T -L 3 -a -I 'node_modules|.git|.cache' --icons"
+lt = "eza -T -L 3 -a -I 'node_modules|.git|.cache' --icons"
+eta = "eza -T -a -I 'node_modules|.git|.cache' --color=always --icons | less -r"
+lta = "eza -T -a -I 'node_modules|.git|.cache' --color=always --icons | less -r"
+fbr = "mise run fbr"
+
 [task_config]
 dir = "{{ config_root }}/tasks"


### PR DESCRIPTION
## Summary
- Move all shell aliases (vi, eza aliases, fbr) from .zshrc to mise's [shell_alias] section
- Simplifies .zshrc by centralizing alias configuration in mise
- Requires mise 2025.11+ for shell_alias support

## Test plan
- [ ] Update mise to latest version (`mise self-update`)
- [ ] Open new terminal and verify aliases work (`ll`, `ls`, `vi`, `fbr`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)