### PR TITLE
Introduce APM-managed agent dependencies

### DIFF
--- a/.github/workflows/apm.yml
+++ b/.github/workflows/apm.yml
@@ -1,0 +1,42 @@
+name: APM
+
+on:
+  pull_request:
+    paths:
+      - "apm/**"
+      - "mise/config.toml"
+      - "mise/hooks/postinstall.sh"
+      - "mise/tasks/apm/**"
+      - ".github/workflows/apm.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apm/**"
+      - "mise/config.toml"
+      - "mise/hooks/postinstall.sh"
+      - "mise/tasks/apm/**"
+      - ".github/workflows/apm.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      HOME: ${{ runner.temp }}/apm-home
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v3
+        with:
+          install: false
+
+      - name: Install APM CLI with mise
+        run: mise install github:microsoft/apm
+
+      - name: Install APM dependencies in isolated global scope
+        run: mise run apm:install
+
+      - name: Audit APM dependencies
+        run: mise run apm:audit

--- a/apm/.gitignore
+++ b/apm/.gitignore
@@ -1,0 +1,4 @@
+
+# APM dependencies
+apm_modules/
+config.json

--- a/apm/README.md
+++ b/apm/README.md
@@ -1,0 +1,67 @@
+# APM
+
+Agent Package Manager configuration for shared agent dependencies.
+
+This directory is the source of truth for APM-managed agent packages. The
+manifest intentionally starts with external Claude official plugins that are
+already used locally. Codex native plugin enablement still lives in
+`~/.codex/config.toml` because APM's Codex support is currently strongest for
+compiled instructions and cross-client skills.
+
+## Usage
+
+Install the APM CLI through mise:
+
+```bash
+mise install github:microsoft/apm
+```
+
+The `apm:*` mise tasks link this repository's APM directory into the user-scope
+APM directory automatically:
+
+```bash
+~/.apm -> ~/dotfiles/apm
+```
+
+Preview what APM would deploy:
+
+```bash
+mise run apm:dry-run
+```
+
+Audit installed APM packages and the manifest:
+
+```bash
+mise run apm:audit
+```
+
+Install the manifest to user scope:
+
+```bash
+mise run apm:install
+```
+
+Update managed dependencies and then audit the result:
+
+```bash
+mise run apm:update
+mise run apm:audit
+```
+
+The mise tasks run from this directory and call:
+
+```bash
+apm install --global
+```
+
+`mise run apm:audit` creates a temporary audit root and symlinks `apm.yml`,
+`apm.lock.yaml`, `.claude`, and `.agents` into it. This mirrors APM's
+lockfile-relative deployed paths while keeping the source manifest in `~/.apm`.
+
+## CI
+
+The GitHub Actions workflow uses `jdx/mise-action`, installs
+`github:microsoft/apm` through mise, uses a temporary `HOME`, installs this
+manifest with `--global`, and runs `apm audit --ci`. This checks dependency
+resolution, deployment, and basic supply-chain hygiene without touching a real
+developer home directory.

--- a/apm/apm.lock.yaml
+++ b/apm/apm.lock.yaml
@@ -1,0 +1,53 @@
+lockfile_version: '1'
+generated_at: '2026-05-03T15:49:21.618123+00:00'
+apm_version: 0.12.0
+dependencies:
+- repo_url: anthropics/claude-plugins-official
+  host: github.com
+  resolved_commit: 55b58ec6e5649104f926ba7558b567dc8d33c5ff
+  resolved_ref: 55b58ec6e5649104f926ba7558b567dc8d33c5ff
+  virtual_path: plugins/claude-code-setup
+  is_virtual: true
+  package_type: marketplace_plugin
+  deployed_files:
+  - .agents/skills/claude-automation-recommender
+  - .claude/skills/claude-automation-recommender
+  content_hash: sha256:ec1d6b7712f33a08de79bc015a5e8e19031fefc4b2ae2debc75e19bda8fcca05
+- repo_url: anthropics/claude-plugins-official
+  host: github.com
+  resolved_commit: 55b58ec6e5649104f926ba7558b567dc8d33c5ff
+  resolved_ref: 55b58ec6e5649104f926ba7558b567dc8d33c5ff
+  virtual_path: plugins/claude-md-management
+  is_virtual: true
+  package_type: marketplace_plugin
+  deployed_files:
+  - .agents/skills/claude-md-improver
+  - .claude/skills/claude-md-improver
+  content_hash: sha256:eef0aa5a71845be937066ef304fbd152d523d2574587474d342def4c3e8514d4
+- repo_url: anthropics/claude-plugins-official
+  host: github.com
+  resolved_commit: 2cd88e7947b7382e045666abee790c7f55f669f3
+  resolved_ref: 2cd88e7947b7
+  virtual_path: plugins/commit-commands
+  is_virtual: true
+  package_type: marketplace_plugin
+  deployed_files:
+  - .claude/commands/clean_gone.md
+  - .claude/commands/commit-push-pr.md
+  - .claude/commands/commit.md
+  deployed_file_hashes:
+    .claude/commands/clean_gone.md: sha256:24ce5c79da87b481d346d26b297cbe327862f1e4bbee05406589f4b5468c7fa3
+    .claude/commands/commit-push-pr.md: sha256:63ee94bcf2a60101d542ec46bf2afa18b31565105ebfc63f1a38e4d308d3cd2f
+    .claude/commands/commit.md: sha256:366740b9d9f45e05bf7cc5b703156f95fe28180012899ceb90d89d34d4110e47
+  content_hash: sha256:059c0e9031132bf71628f984c7411a01543950f17c879100d23145c1bc28c7e1
+- repo_url: anthropics/claude-plugins-official
+  host: github.com
+  resolved_commit: 55b58ec6e5649104f926ba7558b567dc8d33c5ff
+  resolved_ref: 55b58ec6e5649104f926ba7558b567dc8d33c5ff
+  virtual_path: plugins/skill-creator
+  is_virtual: true
+  package_type: marketplace_plugin
+  deployed_files:
+  - .agents/skills/skill-creator
+  - .claude/skills/skill-creator
+  content_hash: sha256:c8fec944c7c073b04a8f9577e10fe50e00b52b6567c56292145e05284704f637

--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -1,0 +1,21 @@
+name: boykush-agent-config
+version: 0.1.0
+description: Shared agent configuration dependencies for local Claude Code and Codex use.
+author: boykush
+target: [claude, codex]
+
+dependencies:
+  apm:
+    # Claude official plugins currently used in the global Claude Code setup.
+    - git: https://github.com/anthropics/claude-plugins-official.git
+      path: plugins/commit-commands
+      ref: 2cd88e7947b7
+    - git: https://github.com/anthropics/claude-plugins-official.git
+      path: plugins/skill-creator
+      ref: 55b58ec6e5649104f926ba7558b567dc8d33c5ff
+    - git: https://github.com/anthropics/claude-plugins-official.git
+      path: plugins/claude-md-management
+      ref: 55b58ec6e5649104f926ba7558b567dc8d33c5ff
+    - git: https://github.com/anthropics/claude-plugins-official.git
+      path: plugins/claude-code-setup
+      ref: 55b58ec6e5649104f926ba7558b567dc8d33c5ff

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -26,6 +26,7 @@ node = "24"
 "aqua:cli/cli" = "2.92.0"
 "aqua:sxyazi/yazi" = "26.1.22"
 "aqua:anthropics/claude-code" = "latest"
+"github:microsoft/apm" = "0.12.1"
 "asdf:mise-plugins/mise-tmux" = "3.6a"
 
 [shell_alias]

--- a/mise/hooks/postinstall.sh
+++ b/mise/hooks/postinstall.sh
@@ -10,6 +10,26 @@ ln -nfs ~/dotfiles/gitui ~/.config/gitui
 ln -nfs ~/dotfiles/helix ~/.config/helix
 ln -nfs ~/dotfiles/claude-code/settings.json ~/.claude/settings.json
 ln -nfs ~/dotfiles/claude-code/claude-dev.json ~/.claude/claude-dev.json
-ln -nfs ~/dotfiles/claude-code/skills ~/.claude/skills
 ln -nfs ~/dotfiles/claude-code/hooks ~/.claude/hooks
 ln -nfs ~/dotfiles/tmux/tmux.conf ~/.tmux.conf
+
+if [ -L ~/.claude/skills ]; then
+  unlink ~/.claude/skills
+fi
+mkdir -p ~/.claude/skills
+
+if [ -e ~/.apm ] && [ ! -L ~/.apm ]; then
+  mv ~/.apm ~/.apm.backup.$(date +%Y%m%d%H%M%S)
+fi
+ln -nfs ~/dotfiles/apm ~/.apm
+
+# APM-managed agent dependencies. Keep this best-effort so a transient
+# network or package-manager issue does not break the rest of dotfiles setup.
+if mise which apm >/dev/null 2>&1; then
+  (
+    cd ~/dotfiles/apm &&
+      mise exec -- apm install --global
+  ) || echo "warning: APM install skipped or failed" >&2
+else
+  echo "warning: apm is not installed yet; run 'mise install' again after github:microsoft/apm installs" >&2
+fi

--- a/mise/tasks/apm/audit
+++ b/mise/tasks/apm/audit
@@ -1,0 +1,30 @@
+#!/bin/bash
+#MISE description="Audit APM-managed agent dependencies"
+#MISE dir="{{config_root}}/apm"
+
+set -euo pipefail
+
+APM_DIR=$(pwd)
+if [ -e "$HOME/.apm" ] && [ ! -L "$HOME/.apm" ]; then
+  mv "$HOME/.apm" "$HOME/.apm.backup.$(date +%Y%m%d%H%M%S)"
+fi
+ln -nfs "$APM_DIR" "$HOME/.apm"
+
+AUDIT_ROOT=$(mktemp -d)
+trap 'rm -rf "$AUDIT_ROOT"' EXIT
+
+ln -s "$HOME/.apm/apm.yml" "$AUDIT_ROOT/apm.yml"
+ln -s "$HOME/.apm/apm.lock.yaml" "$AUDIT_ROOT/apm.lock.yaml"
+
+if [ -e "$HOME/.claude" ]; then
+  ln -s "$HOME/.claude" "$AUDIT_ROOT/.claude"
+fi
+
+if [ -e "$HOME/.agents" ]; then
+  ln -s "$HOME/.agents" "$AUDIT_ROOT/.agents"
+fi
+
+(
+  cd "$AUDIT_ROOT" &&
+    mise exec -- apm audit --ci
+)

--- a/mise/tasks/apm/dry-run
+++ b/mise/tasks/apm/dry-run
@@ -1,0 +1,13 @@
+#!/bin/bash
+#MISE description="Preview APM global agent dependency deployment"
+#MISE dir="{{config_root}}/apm"
+
+set -euo pipefail
+
+APM_DIR=$(pwd)
+if [ -e "$HOME/.apm" ] && [ ! -L "$HOME/.apm" ]; then
+  mv "$HOME/.apm" "$HOME/.apm.backup.$(date +%Y%m%d%H%M%S)"
+fi
+ln -nfs "$APM_DIR" "$HOME/.apm"
+
+mise exec -- apm install --global --dry-run

--- a/mise/tasks/apm/install
+++ b/mise/tasks/apm/install
@@ -1,0 +1,13 @@
+#!/bin/bash
+#MISE description="Install APM-managed agent dependencies globally"
+#MISE dir="{{config_root}}/apm"
+
+set -euo pipefail
+
+APM_DIR=$(pwd)
+if [ -e "$HOME/.apm" ] && [ ! -L "$HOME/.apm" ]; then
+  mv "$HOME/.apm" "$HOME/.apm.backup.$(date +%Y%m%d%H%M%S)"
+fi
+ln -nfs "$APM_DIR" "$HOME/.apm"
+
+mise exec -- apm install --global

--- a/mise/tasks/apm/update
+++ b/mise/tasks/apm/update
@@ -1,0 +1,13 @@
+#!/bin/bash
+#MISE description="Update APM-managed agent dependencies globally"
+#MISE dir="{{config_root}}/apm"
+
+set -euo pipefail
+
+APM_DIR=$(pwd)
+if [ -e "$HOME/.apm" ] && [ ! -L "$HOME/.apm" ]; then
+  mv "$HOME/.apm" "$HOME/.apm.backup.$(date +%Y%m%d%H%M%S)"
+fi
+ln -nfs "$APM_DIR" "$HOME/.apm"
+
+mise exec -- apm install --global --update


### PR DESCRIPTION
## Summary
- Add APM (`apm/apm.yml`, `apm/apm.lock.yaml`) to manage agent dependencies, with README and `.gitignore`.
- Add `mise/tasks/apm/{install,update,audit,dry-run}` task scripts and wire `apm` into `mise/config.toml` + `mise/hooks/postinstall.sh`.
- Add `.github/workflows/apm.yml` for CI.

## Test plan
- [ ] `mise run apm:install` succeeds locally
- [ ] `mise run apm:audit` passes
- [ ] `mise run apm:dry-run` shows expected plan
- [ ] CI workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)