### PR TITLE
Fix Renovate aborting every run by granting statuses:write

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,6 +22,9 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  # minimumReleaseAge + internalChecksFilter:strict で renovate/stability-days の
+  # コミットステータスを書くため。無いと 403 で毎 run 中断する。
+  statuses: write
 
 jobs:
   renovate:


### PR DESCRIPTION
## 問題

自己ホスト Renovate (#109 以降) が **毎 run 中断し、PR を1件も作っていなかった**。
6時間ごとの run はすべて「success」表示だが、最初のブランチ処理で 403 により中断していた。

### 根本原因（デバッグ run で確定）

- `minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"` のため、Renovate は
  `renovate/stability-days` の**コミットステータス**を書き込む
- しかしワークフローの `GITHUB_TOKEN` に **`statuses: write` が無い**
- → `POST /statuses/... = 403 "Resource not accessible by integration"`
  (`x-accepted-github-permissions: statuses=write`)
- → `Caught error setting branch status - aborting` →
  `Repository has changed during renovation - aborting`

依存検出 (mise manager, 17 deps) も `mise lock` 実行も正常で、**残る欠落は権限1行のみ**だった。

## 修正

`permissions` に `statuses: write` を追加。

## 検証

マージ後、`workflow_dispatch` (logLevel=debug) で run を回し、
claude-code / cli/cli / fzf / node の lock 更新 PR が実際に作成されることを確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)