### PR TITLE
Use GitHub App token for self-hosted Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,14 +17,11 @@ concurrency:
   group: renovate
   cancel-in-progress: false
 
-# 必要最小限。GITHUB_TOKEN で push / PR / Dependency Dashboard を行う。
+# Renovate は下で発行する GitHub App トークンで push / PR / status / commit を行う。
+# そのためジョブ既定の GITHUB_TOKEN には書き込み権限は不要（read のみ）。
+# 実際に必要な権限(contents / pull-requests / issues / statuses など)は App 側で付与する。
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  # minimumReleaseAge + internalChecksFilter:strict で renovate/stability-days の
-  # コミットステータスを書くため。無いと 403 で毎 run 中断する。
-  statuses: write
+  contents: read
 
 jobs:
   renovate:
@@ -43,13 +40,24 @@ jobs:
         with:
           install: false
 
+      # GitHub App トークンを発行する。
+      # 既定の GITHUB_TOKEN だと commit status 作成が 422 になり、Renovate が
+      # PR 作成前に中断してしまう（status 書き込みエラーを致命扱いするため）。
+      # App トークンに切り替えると status / commit が通り、PR も CI 発火する（公式推奨）。
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
       - name: Run Renovate
         run: npx --yes renovate
         env:
-          # 組み込みトークン（PAT 不要）。push / PR 用。
-          RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GitHub App トークン（PAT 不使用）。push / PR / status / commit に使用。
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
           # mise lock が GitHub API を叩く際のレート制限回避用。
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RENOVATE_REPOSITORIES: boykush/dotfiles
           # ランナーに入れた mise を使う。
           RENOVATE_BINARY_SOURCE: global


### PR DESCRIPTION
## 背景

`statuses: write` 追加 (#110) で 403 は解消したが、自己ホスト Renovate は
依然 PR を作れていなかった。デバッグ run で原因を特定:

- Renovate はブランチ push・`mise lock`・依存検出(17件)まで正常
- だが `POST /statuses/{sha}` (context `renovate/stability-days`) が **422**
  - 同じ POST はユーザートークンでは成功 → **`GITHUB_TOKEN` 固有**
- Renovate がそのエラー本体のパースに失敗 (`err.body?.errors?.find is not a function`)
  し、**致命的な `Repository has changed during renovation - aborting` に化けて中断**
- 実証: claude-code ブランチに stability status を手動 POST した後の run でのみ
  PR #111 が作成された（status さえ通れば PR 作成・lock 更新は完全動作）

## 変更

`RENOVATE_TOKEN` / `GITHUB_TOKEN` を `actions/create-github-app-token` 発行の
**GitHub App トークン**に切替。

- status 422 を解消（App は commit status を正しく書ける）
- 副次効果: App トークン製 PR は CI が発火する（GITHUB_TOKEN 製は発火しない既知問題）
- ジョブ権限は `contents: read` に縮小（書き込みは App 側の権限で付与）

## マージ前に必要な手動セットアップ ⚠️

1. **GitHub App を作成**（Settings → Developer settings → GitHub Apps → New）
   - Repository permissions:
     - Contents: **Read and write**
     - Pull requests: **Read and write**
     - Issues: **Read and write**（Dependency Dashboard 用）
     - **Commit statuses: Read and write**（← 今回の 422 の核心）
     - Metadata: Read-only（必須・自動）
   - Webhook: Active のチェックを外す
2. **Private key を生成**（.pem をダウンロード）
3. App を **`boykush/dotfiles` にインストール**
4. リポジトリ secrets を追加:
   - `RENOVATE_APP_ID` = App の ID
   - `RENOVATE_APP_PRIVATE_KEY` = .pem の中身

セットアップ後にマージ → `workflow_dispatch`(debug) で検証予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)