### PR TITLE
Fix Renovate App token: read app-id from vars, not secrets

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -48,7 +48,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          # App ID は機密ではない公開識別子なので Variables に置く。秘匿は private-key のみ。
+          app-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
       - name: Run Renovate


### PR DESCRIPTION
## What

Change the Renovate workflow to read the GitHub App ID from `vars.RENOVATE_APP_ID` instead of `secrets.RENOVATE_APP_ID`.

## Why

PR #112 switched self-hosted Renovate to a GitHub App token via `actions/create-github-app-token`, but it referenced `secrets.RENOVATE_APP_ID`. The App ID is registered as a repository **Variable** (it's a public identifier, not a secret), so `secrets.RENOVATE_APP_ID` resolved to an empty string and the token step failed on every run:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

(failing run: https://github.com/boykush/dotfiles/actions/runs/27892858028/job/82539321665)

## Notes for reviewer

- Storing the App ID in Variables is correct and safe — only the private key is sensitive, and it stays in Secrets. This matches the `actions/create-github-app-token` recommended setup (`app-id: vars.*`, `private-key: secrets.*`).
- The `Input 'app-id' has been deprecated, use 'client-id' instead` log line is a non-fatal warning. `client-id` is a different value (`Iv23li…`) from the numeric App ID we already have, so `app-id` is kept intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)