### PR TITLE
Drop non-functional mise github.credential_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ mise install
 
 - **Homebrew**: `Brewfile`で宣言的に管理
 - **mise**: `mise/config.toml`で管理
-- **GitHubトークン**: `ghtkn`で発行（git の credential helper / gh / mise が共用）
+- **GitHubトークン**: `ghtkn`で発行（git の credential helper / gh が利用）

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -2,13 +2,6 @@
 experimental = true
 lockfile = true
 
-[settings.github]
-# mise が GitHub API を叩く際のトークンも ghtkn 経由で取得し、gh / git と統一する。
-# 非対話で走り得るため device flow は無効化し、失効時はハングせず未認証で続行させる
-# （初回認証は `ghtkn auth`、再認証は対話的な git/gh 側で行う）。この設定はグローバル
-# 設定（~/.config/mise = 本 dotfiles の symlink）でのみ有効。ghtkn 未導入時も未認証で続行。
-credential_command = "env GHTKN_ENABLE_DEVICE_FLOW=false ghtkn get -m 1h"
-
 [env]
 XDG_CONFIG_HOME = "{{env.HOME}}/.config"
 LANG = "ja_JP.UTF-8"


### PR DESCRIPTION
## 概要

`[settings.github] credential_command` を削除する。

## 背景

mise はセキュリティ上 `github.credential_command` を**グローバル設定でのみ** honor する。本 dotfiles は `~/.config/mise` を `~/dotfiles/mise` へ symlink しており、mise が実体パス `~/dotfiles/mise/config.toml` を「非グローバル設定」と判定するため、この設定は無視され、毎コマンド次の警告が出ていた:

```
mise WARN  github.credential_command in non-global config /Users/boykush/dotfiles/mise/config.toml is ignored for security reasons
```

## 影響

- **実害なし**。mise は全ツールが public + 共有キャッシュ(mise-versions)で動くため GitHub トークンはほぼ不要。
- git(HTTPS) の credential helper、gh の `[shell_alias]` による ghtkn 連携は**別系統で影響なし**(検証済み)。
- 将来 rate limit 等で必要になれば `MISE_GITHUB_TOKEN` を都度設定すればよい。

## 変更

- `mise/config.toml`: `[settings.github] credential_command` 削除
- `README.md`: トークンの利用先表記から mise を除外

🤖 Generated with [Claude Code](https://claude.com/claude-code)
