### PR TITLE
Disable ghtkn device flow in Claude Code env for AI agents

### DIFF
--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -12,5 +12,8 @@
   "effortLevel": "xhigh",
   "skipDangerousModePermissionPrompt": true,
   "skipWorkflowUsageWarning": true,
-  "enableRemoteControl": true
+  "enableRemoteControl": true,
+  "env": {
+    "GHTKN_ENABLE_DEVICE_FLOW": "false"
+  }
 }


### PR DESCRIPTION
## 概要

AI エージェント（Claude Code）が gh/git で ghtkn の短命トークンを使う際、**トークン失効時にハングしない**よう、AI の Bash 環境で device flow を無効化する。`claude-code/settings.json` の `env` に `GHTKN_ENABLE_DEVICE_FLOW=false` を追加するのみ。

## なぜ

device flow は人間がブラウザで pass code を承認する必要があり、AI（非対話）では完結できない。デフォルト（device flow 有効）だと AI の `ghtkn get` が失効時にポーリングで**ハング**する。

`GHTKN_ENABLE_DEVICE_FLOW=false` を AI の env に入れると:

- 失効時 `ghtkn get` は**即エラー**（ハングしない）。
- そのエラーには ghtkn 自身が「**coding agent はユーザに `ghtkn auth` を依頼せよ**」と明記しているので、AI は正しい回復（ユーザへ依頼 → 承認後に再開）へ進める。
- 対話ユーザのシェルは別環境なので、透過 device flow は**無傷**。

## 変更

- `claude-code/settings.json`: `env.GHTKN_ENABLE_DEVICE_FLOW = "false"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
