### PR TITLE
feat: gh の GH_TOKEN を mise [env] で供給し alias を廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ mise install
 
 `mise install`時（postinstall）に、`ghtkn auth`（device flow＝ブラウザ承認）と旧 gh ログインの破棄が自動実行される（対話端末のみ。CI/非対話ではスキップ）。これで認証とフォールバック遮断が揃い ghtkn に一本化される。
 
-トークンは8時間で失効するが、失効後も git（HTTPS）/ gh が必要時に`ghtkn get`で device flow を自動起動するため、再`mise install`しなくても認証は継続する。
+トークンは8時間で失効する。再`mise install`は不要で、対話端末で `ghtkn auth` を打ち直せば復帰する（コーディングエージェント等の非対話環境では暴発防止のため device flow を無効化しており、自動再取得はされない）。
 
 ## パッケージ管理
 

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -7,6 +7,12 @@ XDG_CONFIG_HOME = "{{env.HOME}}/.config"
 LANG = "ja_JP.UTF-8"
 EDITOR = "hx"
 BAT_THEME = "Nord"
+# gh / git 等が参照する GH_TOKEN を ghtkn の短命トークンで供給する（gh auth login の代替）。
+# shell_alias と違い実環境変数なので、alias を展開しない gh 呼び出し（Claude Desktop の
+# PR 連携など、子プロセス経由）にも伝播する。失効時は ghtkn get が非ゼロ終了するため
+# `|| true` で空にし、mise が全シェルでエラーを吐くのを防ぐ（空なら gh が未認証に
+# フォールバックするだけで、`ghtkn auth` 後に自然復帰）。再評価は shell 起動/cd/設定変更時のみ。
+GH_TOKEN = "{{ exec(command='ghtkn get 2>/dev/null || true') }}"
 
 [tools]
 node = "24"
@@ -45,10 +51,6 @@ eta = "eza -T -a -I 'node_modules|.git|.cache' --color=always --icons | less -r"
 lta = "eza -T -a -I 'node_modules|.git|.cache' --color=always --icons | less -r"
 fbr = "mise run fbr"
 fkill = "mise run fkill"
-# gh: 実行時に ghtkn の短命トークンを GH_TOKEN へ注入する（gh auth login の代替）。
-# 値はシングルクォートで保持され $(ghtkn get) は gh 実行時に遅延評価。command で alias 再帰を回避。
-# .zshrc に直書きせず mise が hook-env で alias を注入する（fbr/fkill と同じ仕組み）。
-gh = 'GH_TOKEN="$(ghtkn get)" command gh'
 gst = "git status -s | awk '{print $2}' | xargs -I {} eza -l --git --icons --no-permissions --no-filesize --no-user --no-time {}"
 
 [task_config]


### PR DESCRIPTION
## 背景 / 問題

Claude Desktop の「PR 作成後のリンク連携」など、**シェル alias を展開せず `gh` を直接 spawn する経路**でトークンが渡らず「未認証」になっていた。

原因はトークン供給が zsh の `shell_alias`（`gh='GH_TOKEN="$(ghtkn get)" command gh'`）限定だったこと。alias はシェル機能で子プロセスに伝播せず、`GH_TOKEN`/`GITHUB_TOKEN` は実環境変数としては空だった。

実証（修正前）:
```
$ command gh auth status   # alias を通さない = Desktop 内蔵経路
You are not logged into any GitHub hosts.
```

## 変更内容

- `mise/config.toml` の `[env]` で `GH_TOKEN` を ghtkn の短命トークンから**実環境変数**として供給:
  `GH_TOKEN = "{{ exec(command='ghtkn get 2>/dev/null || true') }}"`
  alias と違い、alias を展開しない gh 呼び出し（子プロセス経由）にも伝播する。
- 失効時は `ghtkn get` が非ゼロ終了するため `|| true` で空にし、mise が全シェルでエラーを吐くのを防止（空なら gh は未認証にフォールバック、`ghtkn auth` 後に自然復帰）。
- 役割が重複する `[shell_alias]` の `gh` を削除して一本化。
- README を config コメントと重複しない範囲に整理。

## 検証

```
$ command gh auth status   # 非 alias 経路
✓ Logged in to github.com account boykush (GH_TOKEN)
```

- `mise activate` 経路では `ghtkn get` の再実行は shell 起動 / cd / 設定変更時のみ（毎プロンプトでは叩かない）。
- トークン失効を模擬しても mise のエラー出力は 0 件。

## レビュー観点 / 留保

- `exec()` テンプレはグローバル設定（`~/.config/mise` → 本リポジトリ symlink）で評価される。trust 済みで ERROR なしを確認済み。
- 残る留保: Desktop の当該機能がプロファイルを一切読まない完全なアプリ直 spawn の場合はこの env も届かない。その場合の次善策は `gh auth login --with-token`（8h トークンを gh に保存）。本 PR のクリーンな方法をまず適用し、Desktop 再起動後に PR 連携で最終確認する想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
