### PR TITLE
feat: GitHub 認証の既定を gh とし ghtkn をマーカー＋mise task でオプトインに

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -25,8 +25,14 @@
   pushh = push origin HEAD
   pushf = push -f origin HEAD
 
-# GitHub への HTTPS 認証は ghtkn の短命トークンを使う（gh auth setup-git の代替）。
-# 最初の空 helper で既定（osxkeychain 等）をリセットしてから ghtkn を登録する。
+# GitHub への HTTPS 認証は既定で gh auth login（gh auth git-credential）を使う。
+# 最初の空 helper で既定（osxkeychain 等）をリセットしてから gh を登録する。
 [credential "https://github.com"]
 	helper =
-	helper = !ghtkn git-credential
+	helper = !gh auth git-credential
+
+# 環境別のローカル上書き（任意・非追跡）。~/.gitconfig.ghtkn があれば後勝ちで取り込み、
+# 中の空 helper が上の gh を打ち消して ghtkn の短命トークンに切り替える。無ければ gh のまま。
+# このファイルの有無は mise / postinstall も認証系統の判定に使う。
+[include]
+	path = ~/.gitconfig.ghtkn

--- a/README.md
+++ b/README.md
@@ -16,18 +16,17 @@ miseを中心とした開発環境の設定ファイル群です。
 mise install
 ```
 
-### 3. GitHub 認証（ghtkn）
+### 3. GitHub 認証
 
-`gh auth login`は使わず、[ghtkn](https://github.com/suzuki-shunsuke/ghtkn)が発行する短命（8時間）のGitHub App User Access Tokenに統一する。
+既定は `gh auth login`。ghtkn を使わない環境は `gh auth login` するだけ（git も gh も gh の保存トークンを利用）。
 
-事前にdevice flowを有効にしたGitHub Appを1つ用意し、そのClient IDを`ghtkn/ghtkn.yaml`に記入しておく（Client IDは機密ではないためコミット可）。
+GitHub App の短命トークン（8時間／[ghtkn](https://github.com/suzuki-shunsuke/ghtkn)）を使う環境は:
 
-`mise install`時（postinstall）に、`ghtkn auth`（device flow＝ブラウザ承認）と旧 gh ログインの破棄が自動実行される（対話端末のみ。CI/非対話ではスキップ）。これで認証とフォールバック遮断が揃い ghtkn に一本化される。
-
-トークンは8時間で失効する。再`mise install`は不要で、対話端末で `ghtkn auth` を打ち直せば復帰する（コーディングエージェント等の非対話環境では暴発防止のため device flow を無効化しており、自動再取得はされない）。
+1. device flow を有効にした GitHub App を用意し、Client ID を `ghtkn/ghtkn.yaml` に記入（機密ではないためコミット可）。
+2. `mise run ghtkn:on` で切り替え（`~/.gitconfig.ghtkn` 作成＋`ghtkn auth`＝device flow）。トークン失効後も `mise run ghtkn:on` か `ghtkn auth` で復帰。戻すときは `mise run ghtkn:off`。
 
 ## パッケージ管理
 
 - **Homebrew**: `Brewfile`で宣言的に管理
 - **mise**: `mise/config.toml`で管理
-- **GitHubトークン**: `ghtkn`で発行（git の credential helper / gh が利用）
+- **GitHub認証**: 既定は `gh auth login`、任意で `ghtkn`（GitHub App 短命トークン）に切替可

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -7,12 +7,12 @@ XDG_CONFIG_HOME = "{{env.HOME}}/.config"
 LANG = "ja_JP.UTF-8"
 EDITOR = "hx"
 BAT_THEME = "Nord"
-# gh / git 等が参照する GH_TOKEN を ghtkn の短命トークンで供給する（gh auth login の代替）。
-# shell_alias と違い実環境変数なので、alias を展開しない gh 呼び出し（Claude Desktop の
-# PR 連携など、子プロセス経由）にも伝播する。失効時は ghtkn get が非ゼロ終了するため
-# `|| true` で空にし、mise が全シェルでエラーを吐くのを防ぐ（空なら gh が未認証に
-# フォールバックするだけで、`ghtkn auth` 後に自然復帰）。再評価は shell 起動/cd/設定変更時のみ。
-GH_TOKEN = "{{ exec(command='ghtkn get 2>/dev/null || true') }}"
+# GitHub 認証の既定は gh auth login。その場合 GH_TOKEN は空で、gh は自身の保存トークンを使う。
+# ~/.gitconfig.ghtkn がある環境のみ ghtkn の短命トークンを GH_TOKEN に供給する（git も同
+# ファイルの include で ghtkn git-credential に切り替わり認証系統が揃う）。実環境変数なので、
+# alias を展開しない gh 呼び出し（子プロセス経由）にも伝播する。失効時は ghtkn get が非ゼロ
+# 終了するため `|| true` で空にする。再評価は shell 起動/cd/設定変更時のみ。
+GH_TOKEN = "{{ exec(command='[ -f $HOME/.gitconfig.ghtkn ] && ghtkn get 2>/dev/null || true') }}"
 
 [tools]
 node = "24"

--- a/mise/hooks/postinstall.sh
+++ b/mise/hooks/postinstall.sh
@@ -16,18 +16,3 @@ ln -nfs ~/dotfiles/claude-code/claude-dev.json ~/.claude/claude-dev.json
 ln -nfs ~/dotfiles/claude-code/skills ~/.claude/skills
 ln -nfs ~/dotfiles/claude-code/hooks ~/.claude/hooks
 ln -nfs ~/dotfiles/tmux/tmux.conf ~/.tmux.conf
-
-# gh の旧ログイン（長命トークン）は使わず ghtkn に一本化する。保存トークンが
-# 残っていれば破棄してフォールバックを断つ。ローカル処理のみ(~20ms)・冪等で、
-# gh 未導入や未ログインでも安全に no-op（revoke はしない）。
-command -v gh >/dev/null 2>&1 && gh auth logout --hostname github.com </dev/null >/dev/null 2>&1 || true
-
-# ghtkn で事前認証（device flow）。enter フックを廃止したので明示的な mise install 時のみ走る。
-# device flow は対話端末が必須。制御端末(/dev/tty)が無い CI/非対話ではスキップし無限ハングを防ぐ。
-if command -v ghtkn >/dev/null 2>&1; then
-  if { true >/dev/tty; } 2>/dev/null; then
-    ghtkn auth </dev/tty >/dev/tty 2>&1 || true
-  else
-    echo "[postinstall] 非対話のため ghtkn auth をスキップ（対話端末で mise install すれば認証されます）" >&2
-  fi
-fi

--- a/mise/tasks/ghtkn/off
+++ b/mise/tasks/ghtkn/off
@@ -1,0 +1,5 @@
+#!/bin/bash
+#MISE description="GitHub 認証を既定(gh auth login)に戻す（marker 削除）"
+
+rm -f ~/.gitconfig.ghtkn
+echo "既定(gh)に戻しました。'gh auth login' で認証してください。新しいシェルで反映されます。"

--- a/mise/tasks/ghtkn/on
+++ b/mise/tasks/ghtkn/on
@@ -1,0 +1,17 @@
+#!/bin/bash
+#MISE description="GitHub 認証を ghtkn に切替（marker 作成 + device flow 認証）"
+
+# git/mise/gh を ghtkn の短命トークンへ切り替えるマーカー（非追跡・このマシン限定）。
+cat > ~/.gitconfig.ghtkn <<'EOF'
+[credential "https://github.com"]
+	helper =
+	helper = !ghtkn git-credential
+EOF
+
+# gh の保存ログインがあれば破棄してフォールバックを断つ（冪等・no-op 安全）。
+command -v gh >/dev/null 2>&1 && gh auth logout --hostname github.com </dev/null >/dev/null 2>&1 || true
+
+# device flow で認証（対話端末必須）。
+ghtkn auth
+
+echo "ghtkn 有効化しました。新しいシェルで反映されます。"


### PR DESCRIPTION
## 何を
GitHub 認証をマシンごとに **gh auth login / ghtkn（GitHub App 短命トークン）** から選べるようにする。コミットされる既定は `gh` とし、ghtkn を使うマシンだけ非追跡マーカー `~/.gitconfig.ghtkn` でオプトインする。

## なぜ
従来は postinstall が全マシンで gh ログイン破棄＋ghtkn 認証を強制していた。マシンによって gh / ghtkn を使い分けられるよう、既定（コミット側）を素の `gh auth login` にし、ghtkn は per-machine の opt-in に変更する。

## どう
- **`.gitconfig`**: 既定 helper を `!gh auth git-credential` に。`~/.gitconfig.ghtkn` があれば後勝ちで include され、中の空 helper が gh を打ち消して `!ghtkn git-credential` に差し替わる（マーカーは git が直接読むファイルなので env 非依存で動く）。
- **`mise/config.toml`**: `GH_TOKEN` をマーカー有のときだけ `ghtkn get` で供給。無ければ空になり gh は自身の保存トークンにフォールバック。
- **`mise/tasks/ghtkn/{on,off}`**: `mise run ghtkn:on` = マーカー作成＋gh ログイン破棄＋`ghtkn auth`（device flow）。`mise run ghtkn:off` = マーカー削除（gh に戻す）。
- **`postinstall.sh`**: device flow を `mise install` の副作用にするのをやめ、symlink 専念に簡素化（認証は上記 task に集約）。
- **`README.md`**: 既定 gh／切替を `mise run ghtkn:on/off` に更新。

## レビュー観点
- マーカー `~/.gitconfig.ghtkn` は**非追跡のローカルファイル**（リポジトリには現れない）。これがある＝そのマシンは ghtkn、という per-machine スイッチ。
- ghtkn を使うマシン: `mise run ghtkn:on`。使わないマシン: `gh auth login` するだけ（マーカー不要＝既定）。
- git は env 非依存（ghtkn helper）なので、`#126` の `.zshenv`（非対話シェルへの mise env 供給）が無い文脈でも認証できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
