### PR TITLE
feat: mise 本体に min_version を設定し Renovate で追従

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,3 +1,7 @@
+# mise 自身の下限バージョン。これ未満の mise で実行するとエラーになる（自動更新ではない）。
+# 更新は brew upgrade mise。上げたら必要に応じてこの値も追従させる。
+min_version = "2026.6.7"
+
 [settings]
 experimental = true
 lockfile = true

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "mise 本体の min_version を追従（組み込み mise manager は [tools] のみ対象）",
+      "managerFilePatterns": [
+        "/^mise/config\\.toml$/"
+      ],
+      "matchStrings": [
+        "min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "jdx/mise",
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }


### PR DESCRIPTION
## 概要

mise 本体の下限バージョン（`min_version`）を `mise/config.toml` に明示し、Renovate で追従できるようにする。

## 変更点

- `mise/config.toml`: `min_version = "2026.6.7"` を追加。これ未満の mise で実行するとエラーになる（自動更新ではなく下限チェック）。更新自体は `brew upgrade mise`。
- `renovate.json`: customManager（regex）を追加。組み込み `mise` manager は `[tools]` セクションしか見ないため、`min_version` は対象外。`jdx/mise` の `github-releases` datasource に追従させる。

## 補足

- mise のタグは `v2026.6.14` 形式だが、`github-releases` datasource が `v` を自動で外してファイル内の `2026.6.7` と比較する。
- `min_version` は下限のみ。PR をマージしても mise 本体は更新されない（更新は `brew upgrade mise`）。位置づけは「追従＋更新リマインド」。
- `renovate-config-validator` は npx がこの環境と噛み合わず未実行。JSON 妥当性（jq）と正規表現が `2026.6.7` を捕捉することは確認済み。実挙動は初回 Renovate 実行で確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)