### PR TITLE
feat: auto-memory を無効化し bypass モード確認の同意記録を削除

### DIFF
--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -10,7 +10,7 @@
     "skill-creator@claude-plugins-official": true
   },
   "effortLevel": "xhigh",
-  "skipDangerousModePermissionPrompt": true,
+  "autoMemoryEnabled": false,
   "skipWorkflowUsageWarning": true,
   "enableRemoteControl": true,
   "env": {


### PR DESCRIPTION
- autoMemoryEnabled: false を追加（desktop / claude CLI 共通でメモリ機能をオフ）
- skipDangerousModePermissionPrompt を削除し bypass モード進入時の確認を再度有効化