### PR TITLE
fix: mise タスクの実行ディレクトリ不在による spawn 失敗を解消

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -58,8 +58,5 @@ fbr = "mise run fbr"
 fkill = "mise run fkill"
 gst = "git status -s | awk '{print $2}' | xargs -I {} eza -l --git --icons --no-permissions --no-filesize --no-user --no-time {}"
 
-[task_config]
-dir = "{{ config_root }}/tasks"
-
 [hooks]
 postinstall = "~/.config/mise/hooks/postinstall.sh"

--- a/mise/tasks/ghtkn/off
+++ b/mise/tasks/ghtkn/off
@@ -1,5 +1,6 @@
 #!/bin/bash
 #MISE description="GitHub 認証を既定(gh auth login)に戻す（marker 削除）"
+#MISE dir="{{cwd}}"
 
 rm -f ~/.gitconfig.ghtkn
 echo "既定(gh)に戻しました。'gh auth login' で認証してください。新しいシェルで反映されます。"

--- a/mise/tasks/ghtkn/on
+++ b/mise/tasks/ghtkn/on
@@ -1,5 +1,6 @@
 #!/bin/bash
 #MISE description="GitHub 認証を ghtkn に切替（marker 作成 + device flow 認証）"
+#MISE dir="{{cwd}}"
 
 # git/mise/gh を ghtkn の短命トークンへ切り替えるマーカー（非追跡・このマシン限定）。
 cat > ~/.gitconfig.ghtkn <<'EOF'


### PR DESCRIPTION
## 概要

mise 更新後、`mise run <task>` で全タスクが下記エラーで起動できなくなっていた問題を修正します。

```
WARN  task directory does not exist: ~/dotfiles/tasks
ERROR failed to execute command: ~/dotfiles/mise/tasks/ghtkn/on
ERROR No such file or directory (os error 2)
```

（`ghtkn:on` だけでなく `fbr` / `claude:*` / `codex:*` を含む全タスクが対象）

## 原因

グローバル設定 `[task_config] dir = "{{ config_root }}/tasks"` がタスクの**作業ディレクトリ**を存在しないパスに指定していた。

- config が `mise/config.toml` 配下にあるため、mise の規則で `config_root` は `mise/` の親 = `~/dotfiles` に解決される（symlink の有無とは無関係）
- 結果 `{{ config_root }}/tasks` → `~/dotfiles/tasks`（不在）。実体のタスクは `~/dotfiles/mise/tasks/` 配下で自動探索されている
- 旧 mise はこの不在 dir を黙認していたが、更新後の mise が実行前 `chdir` の失敗を致命化させ顕在化

スクリプト自体は正常（直接実行は成功）で、`mise run` 経由の spawn 時のみ失敗していた点が切り分けの決め手。

## 変更内容

- `mise/config.toml`: 不正なグローバル `[task_config]` ブロックを削除
- `mise/tasks/ghtkn/on`, `mise/tasks/ghtkn/off`: 他タスクと同じ `#MISE dir="{{cwd}}"` を付与

このリポジトリの既存タスク（`fbr` / `claude:*` / `codex:*`）は全て `#MISE dir="{{cwd}}"` で実行ディレクトリを自己宣言する規約。ヘッダを持たなかった `ghtkn` タスクのみグローバル設定に依存していたため、規約に合わせて統一した。

## 確認

- `mise run ghtkn:off`（非対話）が正常実行（exit 0）することを確認
- `mise task info ghtkn:on|off` の `Directory` が実在する `~/dotfiles`（cwd）に解決されることを確認
- 全タスクが引き続き `mise tasks` で正常に探索されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)