### PR TITLE
feat: セッション開始時に作業ブランチを git pull で最新化

### DIFF
--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -9,6 +9,19 @@
     "claude-md-management@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1 && git pull --ff-only 2>&1 || true"
+          }
+        ]
+      }
+    ]
+  },
   "effortLevel": "xhigh",
   "autoMemoryEnabled": false,
   "skipWorkflowUsageWarning": true,


### PR DESCRIPTION
## 概要

Claude Code のセッション開始時に、作業ブランチ（ほぼ main）を自動で最新化する `SessionStart` hook を `claude-code/settings.json` に追加。

`~/.claude/settings.json` として読まれる共通設定のため、**CLI・desktop 双方**で有効。

## 変更内容

```json
"hooks": {
  "SessionStart": [
    {
      "matcher": "startup",
      "hooks": [
        { "type": "command",
          "command": "git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1 && git pull --ff-only 2>&1 || true" }
      ]
    }
  ]
}
```

## 挙動 / 設計

- セッション開始時の cwd（対象リポジトリ）で実行
- 追跡ブランチがある時だけ `git pull --ff-only` → ほぼ main で最新化
- 非gitディレクトリ / upstream 無し / ff 不可（ローカル差分）→ 何もせず安全に通過
- 末尾 `|| true` でセッション開始をブロックしない
- `matcher` は `startup` のみ（作業途中の `resume` では pull しない）

## レビュー観点

- `resume`/`clear` でも pull したい場合は matcher を `"startup|resume|clear"` に拡張可能
- pull 出力（`Already up to date.` 等）はセッションのコンテキストに注入される