### PR TITLE
chore: Claude の effort level を env で xhigh に強制

### DIFF
--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -14,6 +14,7 @@
   "skipWorkflowUsageWarning": true,
   "enableRemoteControl": true,
   "env": {
-    "GHTKN_ENABLE_DEVICE_FLOW": "false"
+    "GHTKN_ENABLE_DEVICE_FLOW": "false",
+    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh"
   }
 }


### PR DESCRIPTION
## 変更内容

`claude-code/settings.json` の `env` に `CLAUDE_CODE_EFFORT_LEVEL=xhigh` を追加。

```diff
   "env": {
-    "GHTKN_ENABLE_DEVICE_FLOW": "false"
+    "GHTKN_ENABLE_DEVICE_FLOW": "false",
+    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh"
   }
```

## 背景 / なぜ

`settings.json` の `effortLevel: "xhigh"` は CLI 起動時には適用されるが、**Claude Desktop GUI では新規チャットが毎回 `high` で始まり**、手動で xhigh に上げ直す必要があった。

調査の結果：
- Desktop GUI は effort を**セッション単位で永続化**し、「新規セッションの既定」として焼き付けて使う（settings.json の `effortLevel` を毎回読み直さない）。これが反映されない原因。
- 一方 `CLAUDE_CODE_EFFORT_LEVEL` は claude-code バイナリ内で**セッション effort の強制上書き**として実装されており、設定ファイル・GUI の永続化既定より上位で効く（UI 上も "overrides effort this session" と明示される）。

この env を設定することで、CLI・Desktop 双方で新規セッションが常に xhigh で始まる。Opus 4.8 は effort 有効モデルなのでフル動作する。

## レビュアー向け補足

- この変数がある間は **GUI で effort を手動変更しても "Not applied" になり xhigh に固定**される。たまに `max` 等を使いたい場合は値を変更するか一時的に外す必要がある（常に xhigh 運用なら問題なし）。
- 反映にはアプリ/CLI の再起動が必要（env はプロセス起動時に読まれるため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)