### PR TITLE
chore: Claude の effort level を xhigh から max に変更

### DIFF
--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -22,12 +22,12 @@
       }
     ]
   },
-  "effortLevel": "xhigh",
+  "effortLevel": "max",
   "autoMemoryEnabled": false,
   "skipWorkflowUsageWarning": true,
   "enableRemoteControl": true,
   "env": {
     "GHTKN_ENABLE_DEVICE_FLOW": "false",
-    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh"
+    "CLAUDE_CODE_EFFORT_LEVEL": "max"
   }
 }


### PR DESCRIPTION
## 概要

Claude の effort level を `xhigh` から `max` に変更する。

## 変更内容

`claude-code/settings.json` の2箇所を更新:

- `effortLevel`: `xhigh` → `max`
- `env.CLAUDE_CODE_EFFORT_LEVEL`: `xhigh` → `max`

## 背景

前回 #132 / #133 で、CLI・Desktop 双方の新規セッションが常に高い effort で始まるよう `effortLevel` と env の `CLAUDE_CODE_EFFORT_LEVEL` を `xhigh` に設定した。今回はその上限を `max` に引き上げる。`CLAUDE_CODE_EFFORT_LEVEL` がセッション effort の強制上書きとして効くため、CLI・Desktop 双方で新規セッションが常に `max` で始まる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)