### PR TITLE
feat: npm の既定レジストリを Takumi Guard プロキシに設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ GitHub App の短命トークン（8時間／[ghtkn](https://github.com/suzuki-s
 
 - **Homebrew**: `Brewfile`で宣言的に管理
 - **mise**: `mise/config.toml`で管理
+- **npm**: `mise/config.toml`の`NPM_CONFIG_REGISTRY`で既定レジストリを [Takumi Guard](https://shisho.dev/docs/t/guard/quickstart/)（悪意あるパッケージのブロックプロキシ）に設定
 - **GitHub認証**: 既定は `gh auth login`、任意で `ghtkn`（GitHub App 短命トークン）に切替可

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -12,6 +12,10 @@ XDG_CONFIG_HOME = "{{env.HOME}}/.config"
 LANG = "ja_JP.UTF-8"
 EDITOR = "hx"
 BAT_THEME = "Nord"
+# Takumi Guard (Flatt Security) の悪意あるパッケージブロックプロキシを npm の既定レジストリにする。
+# 匿名利用でもブロックは有効（識別子付与トークンは任意かつ秘密情報のためコミットしない）。env 設定のため
+# registry に限りプロジェクト直下 .npmrc の registry も上書きする（@scope:registry= は別キーで影響なし）。
+NPM_CONFIG_REGISTRY = "https://npm.flatt.tech/"
 # GitHub 認証の既定は gh auth login。その場合 GH_TOKEN は空で、gh は自身の保存トークンを使う。
 # ~/.gitconfig.ghtkn がある環境のみ ghtkn の短命トークンを GH_TOKEN に供給する（git も同
 # ファイルの include で ghtkn git-credential に切り替わり認証系統が揃う）。実環境変数なので、


### PR DESCRIPTION
## 概要

npm の既定レジストリを [Takumi Guard](https://shisho.dev/docs/t/guard/quickstart/)（Flatt Security / Takumi byGMO）のセキュリティプロキシ `npm.flatt.tech` に向け、悪意ある npm パッケージをインストール前にブロックする（サプライチェーン対策）。

## 変更内容

- `mise/config.toml` の `[env]` に `NPM_CONFIG_REGISTRY = "https://npm.flatt.tech/"` を追加
- `README.md` のパッケージ管理に npm の項目を追記

## なぜ mise `[env]` か

- mise 中心のリポジトリ方針に合わせ、`node = "24"` や `GH_TOKEN` と同じく `mise/config.toml` 一箇所で完結
- 新規ファイル・symlink・`setup-brew.sh` の追記が不要。既存の `~/.config/mise` symlink でそのまま配布
- 対話シェル（`.zshrc` の `mise activate`）／非対話シェル（`.zshenv` の `mise env`）の両方でカバー

## 把握しておくべき点

- **匿名モード**でもブロックは有効。識別子付与トークン (`tg_anon_` / `tg_org_`) は任意かつ秘密情報のため非コミット
- env 方式のため `registry` はプロジェクト直下 `.npmrc` の `registry=` も上書きする（`@scope:registry=` は別キーなので private スコープは影響なし）
- 全 npm install が `npm.flatt.tech` 経由になるため、可用性はこのプロキシに依存

## 動作確認

- `npm config get registry` → `https://npm.flatt.tech/`
- `npm view is-odd version` → `3.0.1`（匿名でプロキシ経由取得 OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
