### PR TITLE
chore: eza を asdf backend から cargo backend へ移行し asdf を全面禁止

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,4 +1,4 @@
-# mise - 全シェル種別で aqua/asdf 管理のバイナリを PATH に通す。
+# mise - 全シェル種別で aqua/cargo 管理のバイナリを PATH に通す。
 # Codex.app の non-login interactive shell など .zprofile が読まれない
 # 環境からも starship/zoxide を解決できるようここに置く。
 eval "$(/opt/homebrew/bin/mise activate zsh)"

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -5,7 +5,7 @@ min_version = "2026.6.7"
 [settings]
 experimental = true
 lockfile = true
-disable_backends = ["npm", "vfox"]
+disable_backends = ["npm", "vfox", "asdf"]
 
 [env]
 XDG_CONFIG_HOME = "{{env.HOME}}/.config"
@@ -30,7 +30,7 @@ node = "24"
 "aqua:sharkdp/bat" = "0.26.1"
 "aqua:sharkdp/fd" = "10.4.2"
 "aqua:dandavison/delta" = "0.19.2"
-"asdf:mise-plugins/mise-eza" = "0.23.4"
+"cargo:eza" = "0.23.4"
 "aqua:junegunn/fzf" = "0.73.1"
 "aqua:jqlang/jq" = "1.8.1"
 "aqua:extrawurst/gitui" = "0.28.1"

--- a/mise/mise.lock
+++ b/mise/mise.lock
@@ -495,9 +495,9 @@ url = "https://github.com/tmux/tmux-builds/releases/download/v3.6a/tmux-3.6a-mac
 checksum = "sha256:b9b12eaeba43acf5671acf3857d947525440b544185a8db34ea557199a090251"
 url = "https://github.com/tmux/tmux-builds/releases/download/v3.6a/tmux-3.6a-macos-x86_64.tar.gz"
 
-[[tools."asdf:mise-plugins/mise-eza"]]
+[[tools."cargo:eza"]]
 version = "0.23.4"
-backend = "asdf:mise-plugins/mise-eza"
+backend = "cargo:eza"
 
 [[tools.node]]
 version = "24.16.0"


### PR DESCRIPTION
## 概要
eza の asdf backend 依存を除去し、mise の asdf backend を全面禁止する。

## 背景 / なぜ
- eza は macOS 向けバイナリを配布しておらず（最新 v0.23.4 も Linux/Windows のみ）、mise の **aqua backend は `type: cargo` パッケージ非対応**のため `aqua:eza-community/eza` は macOS で導入不可（`package type cargo is not supported in the aqua backend`）。以前 backend 接頭辞を付けた際に eza だけ aqua に載らず asdf へ落ちていたのはこれが理由。
- 旧構成は asdf プラグイン `mise-plugins/mise-eza` が第三者ミラー `cargo-bins/cargo-quickinstall` から macOS バイナリを取得して成立しており、これが唯一の asdf 依存だった。

## 変更内容
- `mise/config.toml`
  - eza を `asdf:mise-plugins/mise-eza` → **`cargo:eza`** に移行（mise が案内する代替。crates.io からソースビルド、Renovate は crate datasource で追従可能）
  - `disable_backends` に **`asdf`** を追加し asdf backend を全面禁止
- `mise/mise.lock` — cargo:eza に更新（asdf エントリ削除）
- `.zshrc` — コメントを `aqua/asdf` → `aqua/cargo` に修正

## 動作確認
- `mise install cargo:eza@0.23.4` 成功（release build 1m46s）
- `mise which eza` → `~/.local/share/mise/installs/cargo-eza/0.23.4/bin/eza`、`eza --version` → v0.23.4
- 旧 asdf eza の install / plugin を撤去し、lock に asdf 残存なしを確認

## レビュー注意点 / 影響
- **scala は asdf backend 専用**（`mise registry scala` → `asdf:mise-plugins/mise-scala`）。global な asdf 禁止により、他プロジェクトで scala を asdf 経由で使う場合は coursier 等へ要移行。
- 新規マシンでは eza が cargo ソースビルドになるため Rust ツールチェーンが必要（フォローアップで `rust` の mise 追加 or cargo-binstall 導入を検討可）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
