### PR TITLE
chore: 未使用のグローバル node ツールを削除

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -24,8 +24,6 @@ NPM_CONFIG_REGISTRY = "https://npm.flatt.tech/"
 GH_TOKEN = "{{ exec(command='[ -f $HOME/.gitconfig.ghtkn ] && ghtkn get 2>/dev/null || true') }}"
 
 [tools]
-node = "24"
-
 # CLI tools (migrated from brew)
 "aqua:sharkdp/bat" = "0.26.1"
 "aqua:sharkdp/fd" = "10.4.2"

--- a/mise/mise.lock
+++ b/mise/mise.lock
@@ -498,35 +498,3 @@ url = "https://github.com/tmux/tmux-builds/releases/download/v3.6a/tmux-3.6a-mac
 [[tools."cargo:eza"]]
 version = "0.23.4"
 backend = "cargo:eza"
-
-[[tools.node]]
-version = "24.16.0"
-backend = "core:node"
-
-[tools.node."platforms.linux-arm64"]
-checksum = "sha256:589f5b6dd4fcfee4dfda73013903c966abaa8abd93dbc9d436544e472b4f0e74"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-arm64.tar.gz"
-
-[tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:85dde27aa73503b03dadfa0410a800067b4e3f702fb7fcaa3beaf284dfcc69e9"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64-musl.tar.gz"
-
-[tools.node."platforms.linux-x64"]
-checksum = "sha256:2faf6a387e9b62b888e21c54f01249fb27537ffecf1842f29f4c919d0a59a0ff"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-x64.tar.gz"
-
-[tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:50df5d8d474892d4f7b906167df36f77f5b93908f63dc532dc568219cab65841"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64-musl.tar.gz"
-
-[tools.node."platforms.macos-arm64"]
-checksum = "sha256:39189dab4eeb15706c424af0ac08a3044c9e48f7db12a7d77f6b7aafc7dd5df6"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz"
-
-[tools.node."platforms.macos-x64"]
-checksum = "sha256:298b4c7b3cb80765c8703e42b90324a4ece3b6634947b89e769c3c980ab55185"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-x64.tar.gz"
-
-[tools.node."platforms.windows-x64"]
-checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111cd56"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"


### PR DESCRIPTION
## 概要
`mise/config.toml` `[tools]` の `node = "24"` と、`mise/mise.lock` の node ロックエントリを削除します。

## 背景
- node は元々 Claude Code を npm backend (`npm:@anthropic-ai/claude-code`) で入れるための依存でした（`72e69c4` **"Restore node for Claude Code npm dependency"**）。
- `7e6fe08` で Claude Code は aqua backend (`aqua:anthropics/claude-code`) に移行済み → node を必要とする理由が消滅。
- 現状 repo 内に node/npm を実行時依存するものは無い（npm backend は `disable_backends` で無効、他ツールは全て aqua/cargo、タスク・フック・statusline も node 不使用）。

## `NPM_CONFIG_REGISTRY` は残す
- `NPM_CONFIG_REGISTRY`（Takumi Guard プロキシ）は mise `[env]` 経由で**シェル全体に撒かれる環境変数**で、npm / **pnpm** / yarn(classic) / npx が読みます。
- node がどこ由来か（プロジェクト mise・corepack・Docker 等）や `disable_backends` とは**独立**に効くため、プロジェクト側パッケージマネージャへのサプライチェーン保護はこの削除で失われません。

## 影響 / 注意
- グローバル node に依存していたプロジェクトは、各自の mise 設定で node を宣言（または corepack）する必要があります。
- 反映は `mise install`（既存の node バイナリを掃除するなら `mise prune`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
