### PR TITLE
chore: mise 本体を brew から bin/mise（bootstrap）へ移行

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -1,7 +1,6 @@
-# mise 本体は brew 管理をやめ bin/mise（bootstrap ラッパー）へ移行したため、bare `mise`
-# が ~/dotfiles/bin/mise に解決されるよう全シェル種別で PATH を通す。.zshenv は全 zsh
-# 起動で読まれるので、非対話エージェント（下の mise env 取り込み）からも解決できる。
-# ネストシェルでの重複防止のため既に含まれていれば追加しない。
+# bare `mise` を bin/mise（bootstrap ラッパー）に解決させるため、全シェル種別で
+# ~/dotfiles/bin を PATH に通す。.zshenv は全 zsh 起動で読まれるので、非対話エージェント
+# （下の mise env 取り込み）からも解決できる。重複防止のため既に含まれていれば追加しない。
 case ":$PATH:" in
   *":$HOME/dotfiles/bin:"*) ;;
   *) export PATH="$HOME/dotfiles/bin:$PATH" ;;

--- a/.zshenv
+++ b/.zshenv
@@ -1,3 +1,12 @@
+# mise 本体は brew 管理をやめ bin/mise（bootstrap ラッパー）へ移行したため、bare `mise`
+# が ~/dotfiles/bin/mise に解決されるよう全シェル種別で PATH を通す。.zshenv は全 zsh
+# 起動で読まれるので、非対話エージェント（下の mise env 取り込み）からも解決できる。
+# ネストシェルでの重複防止のため既に含まれていれば追加しない。
+case ":$PATH:" in
+  *":$HOME/dotfiles/bin:"*) ;;
+  *) export PATH="$HOME/dotfiles/bin:$PATH" ;;
+esac
+
 # 非対話シェル（Claude Code / Codex CLI 等のエージェント）は .zshrc(=mise activate)を
 # 読まないため mise [env] が丸ごと未適用になる（GH_TOKEN/EDITOR/LANG 等が空）。結果
 # gh(PR作成など)が未認証になる。非対話のときだけ mise の env を取り込み揃える。

--- a/.zshrc
+++ b/.zshrc
@@ -1,8 +1,7 @@
 # mise - 全シェル種別で aqua 管理のバイナリを PATH に通す。
 # Codex.app の non-login interactive shell など .zprofile が読まれない
 # 環境からも starship/zoxide を解決できるようここに置く。
-# mise 本体は brew をやめ bin/mise（bootstrap ラッパー）へ移行。bare `mise` が
-# ~/dotfiles/bin/mise に解決されるよう .zshenv で PATH を通してある。
+# bare `mise` は bin/mise（bootstrap ラッパー）に解決される（PATH は .zshenv で通す）。
 eval "$(mise activate zsh)"
 
 # zoxide - smarter cd command

--- a/.zshrc
+++ b/.zshrc
@@ -1,7 +1,9 @@
-# mise - 全シェル種別で aqua/cargo 管理のバイナリを PATH に通す。
+# mise - 全シェル種別で aqua 管理のバイナリを PATH に通す。
 # Codex.app の non-login interactive shell など .zprofile が読まれない
 # 環境からも starship/zoxide を解決できるようここに置く。
-eval "$(/opt/homebrew/bin/mise activate zsh)"
+# mise 本体は brew をやめ bin/mise（bootstrap ラッパー）へ移行。bare `mise` が
+# ~/dotfiles/bin/mise に解決されるよう .zshenv で PATH を通してある。
+eval "$(mise activate zsh)"
 
 # zoxide - smarter cd command
 eval "$(zoxide init zsh)"

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,5 @@
-# CLI tools
-brew "mise"
+# CLI ツールと mise 本体は mise 側で管理する（本体は bin/mise の bootstrap で導入）。
+# Brewfile は GUI アプリ / フォントの宣言に限定する。
 
 # GUI apps
 cask "arc"

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,4 @@
-# CLI ツールと mise 本体は mise 側で管理する（本体は bin/mise の bootstrap で導入）。
-# Brewfile は GUI アプリ / フォントの宣言に限定する。
+# GUI アプリ / フォントのみ宣言する。CLI ツールと mise 本体は mise 管理（本体は bin/mise）。
 
 # GUI apps
 cask "arc"

--- a/README.md
+++ b/README.md
@@ -4,29 +4,42 @@ miseを中心とした開発環境の設定ファイル群です。
 
 ## セットアップ
 
-### 1. brewとmiseのインストール
+新環境に mise を事前インストールする必要はない。リポジトリ同梱の `bin/mise`（`mise generate bootstrap` の出力＝自己インストールラッパー）が mise 本体を取得して実行する。
+
+### 1. リポジトリ取得
+
+```bash
+git clone git@github.com:boykush/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+```
+
+### 2. CLI ツールのインストール（mise 本体も bootstrap で自動取得）
+
+```bash
+./bin/mise install
+```
+
+`bin/mise` は初回に mise 本体を `~/.cache/mise` へ取得してから実行する（mise 未導入でも動く）。リポジトリ内で実行するため `mise/config.toml` がローカル config として読まれ、`[tools]` の CLI ツールが入る。埋込版は renovate が `min_version` と lockstep で追従するため floor を下回らない（任意で最新化するなら `./bin/mise self-update`）。
+
+### 3. dotfiles の適用
+
+`[dotfiles]` に定義したシンボリックリンク（`~/.zshrc` や `~/.config/*` など。mise 設定自身の `~/.config/mise` -> `~/dotfiles/mise` もここで張る）を適用する。`[tools]` と違い自動では張られないため明示実行する。冪等なので再実行しても既存の正しいリンクはそのまま。
+
+```bash
+./bin/mise dotfiles apply
+```
+
+適用状況は `./bin/mise dotfiles status` で確認できる。以降は新しいシェルで `~/dotfiles/bin` が PATH に入り、`mise` はこのラッパーに解決される。
+
+### 4. GUI アプリ / フォント
 
 ```bash
 ./setup-brew.sh
 ```
 
-### 2. ツールのインストール
+Homebrew を導入し、`Brewfile` の cask（ghostty 等）とフォントを入れる。CLI ツールと mise 本体は mise 管理のため Brewfile には含めない。
 
-```bash
-mise install
-```
-
-### 3. dotfiles の適用
-
-`mise/config.toml` の `[dotfiles]` に定義したシンボリックリンクを張る（`~/.zshrc` や `~/.config/*` など）。`[tools]` と違い自動では張られないため明示実行する。冪等なので再実行しても既存の正しいリンクはそのまま。
-
-```bash
-mise dotfiles apply
-```
-
-適用状況は `mise dotfiles status` で確認できる。
-
-### 4. GitHub 認証
+### 5. GitHub 認証
 
 既定は `gh auth login`。ghtkn を使わない環境は `gh auth login` するだけ（git も gh も gh の保存トークンを利用）。
 
@@ -37,8 +50,14 @@ GitHub App の短命トークン（8時間／[ghtkn](https://github.com/suzuki-s
 
 ## パッケージ管理
 
-- **Homebrew**: `Brewfile`で宣言的に管理
-- **mise**: `mise/config.toml`で管理
+- **mise 本体**: `bin/mise`（`mise generate bootstrap` 出力）で導入。brew 管理をやめたので `mise self-update` で最新化できる。版数は renovate が `min_version` と埋込版を lockstep で追従（[更新](#更新)参照）
+- **CLI ツール**: `mise/config.toml`の`[tools]`（aqua backend、checksum 検証あり）で宣言的に管理。renovate が追従
+- **Homebrew**: `Brewfile`で宣言的に管理（GUI cask / フォントのみ）
 - **dotfiles**: `mise/config.toml`の`[dotfiles]`でシンボリックリンクを宣言的に管理（`mise dotfiles apply`で適用）
 - **npm**: `mise/config.toml`の`NPM_CONFIG_REGISTRY`で既定レジストリを [Takumi Guard](https://shisho.dev/docs/t/guard/quickstart/)（悪意あるパッケージのブロックプロキシ）に設定
 - **GitHub認証**: 既定は `gh auth login`、任意で `ghtkn`（GitHub App 短命トークン）に切替可
+
+## 更新
+
+- **mise 本体**: renovate が `min_version` と `bin/mise` の埋込版を lockstep で追従（minimum release age 付き、同じ depName なので1 PR で一括）。日常で最新にしたいときは `mise self-update`。`bin/mise` を綺麗に作り直したいときだけ手動再生成する: `mise generate bootstrap -w bin/mise`（checksum baseline も最新化される）
+- **CLI ツール**: renovate の PR で `[tools]` と `mise.lock` を追従。手動なら `mise upgrade`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ GitHub App の短命トークン（8時間／[ghtkn](https://github.com/suzuki-s
 
 ## パッケージ管理
 
-- **mise 本体**: `bin/mise`（`mise generate bootstrap` 出力）で導入。brew 管理をやめたので `mise self-update` で最新化できる。版数は renovate が `min_version` と埋込版を lockstep で追従（[更新](#更新)参照）
+- **mise 本体**: `bin/mise`（`mise generate bootstrap` 出力）で導入し、`mise self-update` で最新化。版数は renovate が `min_version` と埋込版を lockstep で追従（[更新](#更新)参照）
 - **CLI ツール**: `mise/config.toml`の`[tools]`（aqua backend、checksum 検証あり）で宣言的に管理。renovate が追従
 - **Homebrew**: `Brewfile`で宣言的に管理（GUI cask / フォントのみ）
 - **dotfiles**: `mise/config.toml`の`[dotfiles]`でシンボリックリンクを宣言的に管理（`mise dotfiles apply`で適用）

--- a/bin/mise
+++ b/bin/mise
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+set -eu
+
+__mise_bootstrap() {
+    local cache_home="${XDG_CACHE_HOME:-$HOME/.cache}/mise"
+    export MISE_INSTALL_PATH="$cache_home/mise-2026.7.5"
+    install() {
+        local initial_working_dir="$PWD"
+        #!/bin/sh
+        set -eu
+
+        #region logging setup
+        if [ "${MISE_DEBUG-}" = "true" ] || [ "${MISE_DEBUG-}" = "1" ]; then
+          debug() {
+            echo "$@" >&2
+          }
+        else
+          debug() {
+            :
+          }
+        fi
+
+        if [ "${MISE_QUIET-}" = "1" ] || [ "${MISE_QUIET-}" = "true" ]; then
+          info() {
+            :
+          }
+        else
+          info() {
+            echo "$@" >&2
+          }
+        fi
+
+        warn() {
+          printf '%s\n' "$*" >&2
+        }
+
+        error() {
+          echo "$@" >&2
+          exit 1
+        }
+
+        unsupported_arch() {
+          arch="$1"
+          warn "unsupported architecture: $arch"
+          warn ""
+          warn "mise does not provide prebuilt binaries for this platform."
+          warn "If Rust/Cargo is available, install from source with:"
+          warn "  cargo install --locked mise"
+          exit 1
+        }
+        #endregion
+
+        #region environment setup
+        get_os() {
+          os="$(uname -s)"
+          if [ "$os" = Darwin ]; then
+            echo "macos"
+          elif [ "$os" = Linux ]; then
+            echo "linux"
+          else
+            error "unsupported OS: $os"
+          fi
+        }
+
+        get_arch() {
+          musl=""
+          if type ldd >/dev/null 2>/dev/null; then
+            if [ "${MISE_INSTALL_MUSL-}" = "1" ] || [ "${MISE_INSTALL_MUSL-}" = "true" ]; then
+              musl="-musl"
+            elif [ "$(uname -o)" = "Android" ]; then
+              # Android (Termux) always uses musl
+              musl="-musl"
+            else
+              libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
+              if [ -n "$libc" ]; then
+                musl="-musl"
+              fi
+            fi
+          fi
+          arch="$(uname -m)"
+          if [ "$arch" = x86_64 ]; then
+            echo "x64$musl"
+          elif [ "$arch" = aarch64 ] || [ "$arch" = arm64 ]; then
+            echo "arm64$musl"
+          elif [ "$arch" = armv7l ]; then
+            echo "armv7$musl"
+          else
+            unsupported_arch "$arch"
+          fi
+        }
+
+        get_ext() {
+          if [ -n "${MISE_INSTALL_EXT:-}" ]; then
+            echo "$MISE_INSTALL_EXT"
+          elif [ -n "${MISE_VERSION:-}" ] && echo "$MISE_VERSION" | grep -q '^v2024'; then
+            # 2024 versions don't have zstd tarballs
+            echo "tar.gz"
+          elif tar_supports_zstd; then
+            echo "tar.zst"
+          else
+            echo "tar.gz"
+          fi
+        }
+
+        tar_supports_zstd() {
+          if ! command -v zstd >/dev/null 2>&1; then
+            false
+          # tar is bsdtar
+          elif tar --version | grep -q 'bsdtar'; then
+            true
+          # busybox tar reports a "1.3x" version that matches the GNU check below, but it
+          # cannot decompress .tar.zst itself. Detect it so we fall back to the zstd pipe
+          # (or a .tar.gz download) instead of running `tar -xf` on a zstd tarball.
+          elif tar --version 2>&1 | grep -qi 'busybox'; then
+            false
+          # tar version is >= 1.31
+          elif tar --version | grep -q '1\.\(3[1-9]\|[4-9][0-9]\)'; then
+            true
+          else
+            false
+          fi
+        }
+
+        shasum_bin() {
+          if command -v shasum >/dev/null 2>&1; then
+            echo "shasum"
+          elif command -v sha256sum >/dev/null 2>&1; then
+            echo "sha256sum"
+          else
+            error "mise install requires shasum or sha256sum but neither is installed. Aborting."
+          fi
+        }
+
+        get_checksum() {
+          version=$1
+          os=$2
+          arch=$3
+          ext=$4
+          url="https://github.com/jdx/mise/releases/download/v${version}/SHASUMS256.txt"
+          current_version="v2026.7.5"
+          current_version="${current_version#v}"
+
+          # For current version use static checksum otherwise
+          # use checksum from releases
+          if [ "$version" = "$current_version" ]; then
+            checksum_linux_x86_64="be92da3afb180dc71b3ce6fcaaaf2f393812c9c50e9a64c9cb6706cf28edb486  ./mise-v2026.7.5-linux-x64.tar.gz"
+            checksum_linux_x86_64_musl="e04f7a6820a095ca0451a8745a335fc84d8b0656dcec535361a5de788f6b3065  ./mise-v2026.7.5-linux-x64-musl.tar.gz"
+            checksum_linux_arm64="9020f7453931a6873d60cf204d5935ebd08633b25f675b0820cd06862b4b6450  ./mise-v2026.7.5-linux-arm64.tar.gz"
+            checksum_linux_arm64_musl="25a736fe971ed0645c8124211ae4eaf0309fe646193c3f201b662c8e771ad705  ./mise-v2026.7.5-linux-arm64-musl.tar.gz"
+            checksum_linux_armv7="934f8892c1bcf8678a9c78e53f2d1bef83c9e986abbd272323a01c8979cda5af  ./mise-v2026.7.5-linux-armv7.tar.gz"
+            checksum_linux_armv7_musl="0b113ccbb8c8af243dc2e2e8e5814e4b04379d0007e6831c82e3bdc342855bb4  ./mise-v2026.7.5-linux-armv7-musl.tar.gz"
+            checksum_macos_x86_64="48cc4ae352bd903d5069e9967ebba18dfb0bbd46aa325a82a353b07329ebf57d  ./mise-v2026.7.5-macos-x64.tar.gz"
+            checksum_macos_arm64="ae0c21532774eda198b23a22a7ffbe684f482c074a976a13e0f664af8255e2ae  ./mise-v2026.7.5-macos-arm64.tar.gz"
+            checksum_linux_x86_64_zstd="9aba3d853ec460a7be2c01ac21311b9a1ac9ff37ab1905c74df7f9b55434ddc6  ./mise-v2026.7.5-linux-x64.tar.zst"
+            checksum_linux_x86_64_musl_zstd="29b3d5781cc43caaf47330a410e8a1f60f3d3af46e287e4ea79cd5f64088595a  ./mise-v2026.7.5-linux-x64-musl.tar.zst"
+            checksum_linux_arm64_zstd="c1effcaadaef7afb23b1b7e1b48604ae791c3b525d8a49717321851aa8e62d8b  ./mise-v2026.7.5-linux-arm64.tar.zst"
+            checksum_linux_arm64_musl_zstd="61e54f8d49fc267b46cea8371698a57f6da2d8d4764b0d11edb7e5c76f3cf6c2  ./mise-v2026.7.5-linux-arm64-musl.tar.zst"
+            checksum_linux_armv7_zstd="d6c1b7e04e310c3004a1f33f4df9a117a1b6d07ceb97b4f3c71e3114f5b76fed  ./mise-v2026.7.5-linux-armv7.tar.zst"
+            checksum_linux_armv7_musl_zstd="87d828be8d72583255bfdb1f406c0f4ed40cc6394a9acab7fd287630b8f927c1  ./mise-v2026.7.5-linux-armv7-musl.tar.zst"
+            checksum_macos_x86_64_zstd="4fbe4ecef44bed2d36080efe3f2dcd073e14a377cba8a1ab2ba54cf177e5db30  ./mise-v2026.7.5-macos-x64.tar.zst"
+            checksum_macos_arm64_zstd="d35d9944d036413c33056f1707e09f14ff3580971a0e9bc14fb3a062cd80378b  ./mise-v2026.7.5-macos-arm64.tar.zst"
+
+            # TODO: refactor this, it's a bit messy
+            if [ "$ext" = "tar.zst" ]; then
+              if [ "$os" = "linux" ]; then
+                if [ "$arch" = "x64" ]; then
+                  echo "$checksum_linux_x86_64_zstd"
+                elif [ "$arch" = "x64-musl" ]; then
+                  echo "$checksum_linux_x86_64_musl_zstd"
+                elif [ "$arch" = "arm64" ]; then
+                  echo "$checksum_linux_arm64_zstd"
+                elif [ "$arch" = "arm64-musl" ]; then
+                  echo "$checksum_linux_arm64_musl_zstd"
+                elif [ "$arch" = "armv7" ]; then
+                  echo "$checksum_linux_armv7_zstd"
+                elif [ "$arch" = "armv7-musl" ]; then
+                  echo "$checksum_linux_armv7_musl_zstd"
+                else
+                  warn "no checksum for $os-$arch"
+                fi
+              elif [ "$os" = "macos" ]; then
+                if [ "$arch" = "x64" ]; then
+                  echo "$checksum_macos_x86_64_zstd"
+                elif [ "$arch" = "arm64" ]; then
+                  echo "$checksum_macos_arm64_zstd"
+                else
+                  warn "no checksum for $os-$arch"
+                fi
+              else
+                warn "no checksum for $os-$arch"
+              fi
+            else
+              if [ "$os" = "linux" ]; then
+                if [ "$arch" = "x64" ]; then
+                  echo "$checksum_linux_x86_64"
+                elif [ "$arch" = "x64-musl" ]; then
+                  echo "$checksum_linux_x86_64_musl"
+                elif [ "$arch" = "arm64" ]; then
+                  echo "$checksum_linux_arm64"
+                elif [ "$arch" = "arm64-musl" ]; then
+                  echo "$checksum_linux_arm64_musl"
+                elif [ "$arch" = "armv7" ]; then
+                  echo "$checksum_linux_armv7"
+                elif [ "$arch" = "armv7-musl" ]; then
+                  echo "$checksum_linux_armv7_musl"
+                else
+                  warn "no checksum for $os-$arch"
+                fi
+              elif [ "$os" = "macos" ]; then
+                if [ "$arch" = "x64" ]; then
+                  echo "$checksum_macos_x86_64"
+                elif [ "$arch" = "arm64" ]; then
+                  echo "$checksum_macos_arm64"
+                else
+                  warn "no checksum for $os-$arch"
+                fi
+              else
+                warn "no checksum for $os-$arch"
+              fi
+            fi
+          else
+            if command -v curl >/dev/null 2>&1; then
+              debug ">" curl -fsSL "$url"
+              checksums="$(curl --compressed -fsSL "$url")"
+            else
+              if command -v wget >/dev/null 2>&1; then
+                debug ">" wget -qO - "$url"
+                checksums="$(wget -qO - "$url")"
+              else
+                error "mise standalone install specific version requires curl or wget but neither is installed. Aborting."
+              fi
+            fi
+            # TODO: verify with minisign or gpg if available
+
+            checksum="$(echo "$checksums" | grep "$os-$arch.$ext")"
+            if ! echo "$checksum" | grep -Eq "^([0-9a-f]{32}|[0-9a-f]{64})"; then
+              warn "no checksum for mise $version and $os-$arch"
+            else
+              echo "$checksum"
+            fi
+          fi
+        }
+
+        #endregion
+
+        download_file() {
+          url="$1"
+          download_dir="$2"
+          filename="$(basename "$url")"
+          file="$download_dir/$filename"
+
+          info "mise: installing mise..."
+
+          if command -v curl >/dev/null 2>&1; then
+            debug ">" curl -#fLo "$file" "$url"
+            curl -#fLo "$file" "$url"
+          else
+            if command -v wget >/dev/null 2>&1; then
+              debug ">" wget -qO "$file" "$url"
+              stderr=$(mktemp)
+              wget -O "$file" "$url" >"$stderr" 2>&1 || error "wget failed: $(cat "$stderr")"
+              rm "$stderr"
+            else
+              error "mise standalone install requires curl or wget but neither is installed. Aborting."
+            fi
+          fi
+
+          echo "$file"
+        }
+
+        # Prints the version of an installed mise binary (the first field of
+        # `mise version`, e.g. "2025.6.0"), with any leading "v" stripped. Prints
+        # nothing if the binary is missing or fails to report a version.
+        installed_mise_version() {
+          bin="$1"
+          if [ -x "$bin" ]; then
+            installed_version="$("$bin" version 2>/dev/null | head -n1 | cut -d' ' -f1)"
+            echo "${installed_version#v}"
+          fi
+        }
+
+        install_mise() {
+          version="${MISE_VERSION:-v2026.7.5}"
+          version="${version#v}"
+          current_version="v2026.7.5"
+          current_version="${current_version#v}"
+          os="${MISE_INSTALL_OS:-$(get_os)}"
+          arch="${MISE_INSTALL_ARCH:-$(get_arch)}"
+          ext="${MISE_INSTALL_EXT:-$(get_ext)}"
+          install_path="${MISE_INSTALL_PATH:-$HOME/.local/bin/mise}"
+          install_dir="$(dirname "$install_path")"
+          install_from_github="${MISE_INSTALL_FROM_GITHUB:-}"
+
+          # Opt-in: skip the download/install if the binary already at the install
+          # path matches the requested version. Only the install path is checked (not
+          # the wider PATH) so that skipping never leaves install_path missing.
+          skip_if_exists="${MISE_INSTALL_SKIP_IF_EXISTS-}"
+          if [ "$skip_if_exists" = "1" ] || [ "$skip_if_exists" = "true" ]; then
+            if [ -x "$install_path" ]; then
+              existing_version="$(installed_mise_version "$install_path")"
+              if [ -n "$existing_version" ] && [ "$existing_version" = "$version" ]; then
+                info "mise: $install_path is already at version $version, skipping install"
+                return 0
+              fi
+            fi
+          fi
+          if [ "$version" != "$current_version" ] || [ "$install_from_github" = "1" ] || [ "$install_from_github" = "true" ]; then
+            tarball_url="https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-${os}-${arch}.${ext}"
+          elif [ -n "${MISE_TARBALL_URL-}" ]; then
+            tarball_url="$MISE_TARBALL_URL"
+          else
+            tarball_url="https://mise.jdx.dev/v${version}/mise-v${version}-${os}-${arch}.${ext}"
+          fi
+
+          download_dir="$(mktemp -d)"
+          cache_file=$(download_file "$tarball_url" "$download_dir")
+          debug "mise-setup: tarball=$cache_file"
+
+          debug "validating checksum"
+          cd "$(dirname "$cache_file")" && get_checksum "$version" "$os" "$arch" "$ext" | "$(shasum_bin)" -c >/dev/null
+
+          # extract tarball
+          if [ -d "$install_path" ]; then
+            error "MISE_INSTALL_PATH '$install_path' is a directory. Please set it to a file path, e.g. '$install_path/mise'."
+          fi
+          mkdir -p "$install_dir"
+          rm -f "$install_path"
+          extract_dir="$(mktemp -d)"
+          cd "$extract_dir"
+          if [ "$ext" = "tar.zst" ] && ! tar_supports_zstd; then
+            zstd -d -c "$cache_file" | tar --no-same-owner -xf -
+          else
+            tar --no-same-owner -xf "$cache_file"
+          fi
+          if [ "$(id -u)" = "0" ]; then
+            chown 0:0 mise/bin/mise
+            chmod 755 mise/bin/mise
+          fi
+          mv mise/bin/mise "$install_path"
+
+          # cleanup
+          cd / # Move out of $extract_dir before removing it
+          rm -rf "$download_dir"
+          rm -rf "$extract_dir"
+
+          info "mise: installed successfully to $install_path"
+        }
+
+        after_finish_help() {
+          case "${SHELL:-}" in
+          */zsh)
+            info "mise: run the following to activate mise in your shell:"
+            info "echo \"eval \\\"\\\$($install_path activate zsh)\\\"\" >> \"${ZDOTDIR-$HOME}/.zshrc\""
+            info ""
+            info "mise: run \`mise doctor\` to verify this is set up correctly"
+            ;;
+          */bash)
+            info "mise: run the following to activate mise in your shell:"
+            info "echo \"eval \\\"\\\$($install_path activate bash)\\\"\" >> ~/.bashrc"
+            info ""
+            info "mise: run \`mise doctor\` to verify this is set up correctly"
+            ;;
+          */fish)
+            info "mise: run the following to activate mise in your shell:"
+            info "echo \"$install_path activate fish | source\" >> ~/.config/fish/config.fish"
+            info ""
+            info "mise: run \`mise doctor\` to verify this is set up correctly"
+            ;;
+          *)
+            info "mise: run \`$install_path --help\` to get started"
+            ;;
+          esac
+        }
+
+        install_mise
+        if [ "${MISE_INSTALL_HELP-}" != 0 ]; then
+          after_finish_help
+        fi
+
+        cd -- "$initial_working_dir"
+    }
+    local MISE_INSTALL_HELP=0
+    test -f "$MISE_INSTALL_PATH" || install
+}
+__mise_bootstrap
+exec -a "$0" "$MISE_INSTALL_PATH" "$@"

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,17 +1,16 @@
 # mise 自身の下限バージョン。これ未満の mise で実行するとエラーになる（version と
 # self-update だけは例外的に通る）。renovate が minimum release age 付きで追従し、同じ PR で
 # bin/mise の埋込版も一緒に上がる（lockstep。renovate.json 参照）ため、埋込版がこの floor を
-# 下回ることはない。本体は bin/mise（`mise generate bootstrap` 出力）で導入し、日常の最新化は
-# `mise self-update`（brew 管理下だと拒否されるが bootstrap 導入なら可能）。
+# 下回ることはない。日常の最新化は `mise self-update`。
 min_version = "2026.7.5"
 
 [settings]
 experimental = true
 lockfile = true
 disable_backends = ["npm", "vfox", "asdf"]
-# dotfiles 機能（実験的）。従来 postinstall フックで実行していた ln -nfs を代替する。
+# dotfiles 機能（実験的）。[dotfiles] のシンボリックリンクを宣言的に管理する。
 # root は `mise dotfiles add` で新規ソースを配置する基準。default_mode=symlink により
-# 各エントリは既定でシンボリックリンク（従来の ln -s と同じ挙動）になる。
+# 各エントリは既定でシンボリックリンクになる。
 dotfiles.root = "~/dotfiles"
 dotfiles.default_mode = "symlink"
 
@@ -32,7 +31,7 @@ NPM_CONFIG_REGISTRY = "https://npm.flatt.tech/"
 GH_TOKEN = "{{ exec(command='[ -f $HOME/.gitconfig.ghtkn ] && ghtkn get 2>/dev/null || true') }}"
 
 [tools]
-# CLI tools (migrated from brew)
+# CLI tools
 "aqua:sharkdp/bat" = "0.26.1"
 "aqua:sharkdp/fd" = "10.4.2"
 "aqua:dandavison/delta" = "0.19.2"
@@ -68,14 +67,13 @@ fkill = "mise run fkill"
 # （git ステータスと名前のみ）を明示する。
 gst = "git status -s | awk '{print $2}' | xargs -I {} lsd -l --git --blocks git,name {}"
 
-# dotfiles のシンボリックリンク定義（従来 mise/hooks/postinstall.sh の ln -nfs を移設）。
-# `[tools]` と違い自動では張られず、`mise dotfiles apply` の明示実行時のみ適用される。
-# 値はソースパス（~ 展開あり）。ディレクトリ指定はそのディレクトリごと symlink する。
+# dotfiles のシンボリックリンク定義。`[tools]` と違い自動では張られず、
+# `mise dotfiles apply` の明示実行時のみ適用される。値はソースパス（~ 展開あり）。
+# ディレクトリ指定はそのディレクトリごと symlink する。
 [dotfiles]
-# mise 設定自身（global config の実体）。従来「mise が config を読む前提のため
-# ここでは扱えない」として setup-brew.sh の手動 ln に残していたが、新環境では bin/mise
-# をリポジトリ内で実行すると mise/config.toml がローカル config として読まれるため、
-# この [dotfiles] を apply して自己リンクを張れる（鶏卵問題が解ける）。
+# mise 設定自身（global config の実体）。bin/mise をリポジトリ内で実行すると
+# mise/config.toml がローカル config として読まれるので、この自己リンクも
+# `mise dotfiles apply` で張れる。
 "~/.config/mise" = "~/dotfiles/mise"
 # ホーム直下
 "~/.zprofile"  = "~/dotfiles/.zprofile"

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,6 +1,9 @@
-# mise 自身の下限バージョン。これ未満の mise で実行するとエラーになる（自動更新ではない）。
-# 更新は brew upgrade mise。上げたら必要に応じてこの値も追従させる。
-min_version = "2026.6.7"
+# mise 自身の下限バージョン。これ未満の mise で実行するとエラーになる（version と
+# self-update だけは例外的に通る）。renovate が minimum release age 付きで追従し、同じ PR で
+# bin/mise の埋込版も一緒に上がる（lockstep。renovate.json 参照）ため、埋込版がこの floor を
+# 下回ることはない。本体は bin/mise（`mise generate bootstrap` 出力）で導入し、日常の最新化は
+# `mise self-update`（brew 管理下だと拒否されるが bootstrap 導入なら可能）。
+min_version = "2026.7.5"
 
 [settings]
 experimental = true
@@ -68,9 +71,12 @@ gst = "git status -s | awk '{print $2}' | xargs -I {} lsd -l --git --blocks git,
 # dotfiles のシンボリックリンク定義（従来 mise/hooks/postinstall.sh の ln -nfs を移設）。
 # `[tools]` と違い自動では張られず、`mise dotfiles apply` の明示実行時のみ適用される。
 # 値はソースパス（~ 展開あり）。ディレクトリ指定はそのディレクトリごと symlink する。
-# 注: ~/.config/mise -> ~/dotfiles/mise の1本だけは mise が config を読む前提のため
-# ここでは扱えず、ブートストラップとして setup-brew.sh 側に残している。
 [dotfiles]
+# mise 設定自身（global config の実体）。従来「mise が config を読む前提のため
+# ここでは扱えない」として setup-brew.sh の手動 ln に残していたが、新環境では bin/mise
+# をリポジトリ内で実行すると mise/config.toml がローカル config として読まれるため、
+# この [dotfiles] を apply して自己リンクを張れる（鶏卵問題が解ける）。
+"~/.config/mise" = "~/dotfiles/mise"
 # ホーム直下
 "~/.zprofile"  = "~/dotfiles/.zprofile"
 "~/.zshrc"     = "~/dotfiles/.zshrc"

--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,15 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "mise 本体の min_version を追従（組み込み mise manager は [tools] のみ対象）",
+      "description": "mise 本体を lockstep 追従: config.toml の min_version(floor) と bin/mise(bootstrap) の版数決定2箇所(install path / install version)。同一 depName なので1 PR で一括 bump され min_version と埋込版が常に揃う。bin/mise は生成物だが install する版だけを上げる（current_version と埋込 checksum(146-161行) は baked baseline のまま据え置き。install版 != baseline なので checksum は GitHub から都度取得され検証は保たれる）。綺麗に作り直すときだけ手動 `mise generate bootstrap -w bin/mise`。組み込み mise manager は [tools] のみ対象。",
       "managerFilePatterns": [
-        "/^mise/config\\.toml$/"
+        "/^mise/config\\.toml$/",
+        "/^bin/mise$/"
       ],
       "matchStrings": [
-        "min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        "min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
+        "mise-(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "MISE_VERSION:-v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\}"
       ],
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases"

--- a/setup-brew.sh
+++ b/setup-brew.sh
@@ -14,6 +14,5 @@ fi
 # install packages from Brewfile（GUI アプリ / フォントのみ）
 brew bundle --file=~/dotfiles/Brewfile
 
-# 注: CLI ツールの導入は `./bin/mise install`、~/.config/mise を含む dotfiles の
-# シンボリックリンクは `./bin/mise dotfiles apply` が行う（従来ここにあった手動
-# `ln -nfs ~/dotfiles/mise ~/.config/mise` は mise の [dotfiles] へ移設した）。
+# CLI ツールの導入は `./bin/mise install`、~/.config/mise を含む dotfiles の
+# シンボリックリンクは `./bin/mise dotfiles apply` が行う（README 参照）。

--- a/setup-brew.sh
+++ b/setup-brew.sh
@@ -11,12 +11,9 @@ else
   echo "[INFO] brew is already installed"
 fi
 
-# install packages from Brewfile
+# install packages from Brewfile（GUI アプリ / フォントのみ）
 brew bundle --file=~/dotfiles/Brewfile
 
-# setup config
-## make directory .config
-mkdir -p ~/.config
-
-## link mise config
-ln -nfs ~/dotfiles/mise ~/.config/mise
+# 注: CLI ツールの導入は `./bin/mise install`、~/.config/mise を含む dotfiles の
+# シンボリックリンクは `./bin/mise dotfiles apply` が行う（従来ここにあった手動
+# `ln -nfs ~/dotfiles/mise ~/.config/mise` は mise の [dotfiles] へ移設した）。


### PR DESCRIPTION
## 概要

mise 本体の導入を Homebrew から切り離し、`mise generate bootstrap` 出力の自己インストールラッパー `bin/mise` へ移行します。

**動機**
- `mise self-update` を解禁したい（brew 管理下の mise は self-update を拒否する）
- 新環境で mise の事前インストールを不要にしたい（`git clone` に付いてくる `bin/mise` が本体を取得）

## 変更点

- **Brewfile**: `brew "mise"` を削除（GUI cask / フォント専用に）
- **bin/mise（新規）**: `mise generate bootstrap` 出力。素のシェルスクリプトで、初回に mise 本体を GitHub リリースから `~/.cache/mise` へ取得して exec する（mise 未導入でも動く）
- **mise/config.toml**: `~/.config/mise -> ~/dotfiles/mise` の symlink を `[dotfiles]` へ畳み込み。`bin/mise` をリポジトリ内で実行するとローカル config が読まれるため鶏卵問題が解ける。`min_version` を bin/mise の埋込版に整合（`2026.7.5`）
- **setup-brew.sh**: 手動 `ln -nfs ~/dotfiles/mise ~/.config/mise` と `mkdir` を撤去（上記 `[dotfiles]` へ移設）。brew 導入＋ `Brewfile`（GUI/フォント）のみに
- **.zshenv / .zshrc**: `~/dotfiles/bin` を PATH へ通し、`mise activate` のハードコード `/opt/homebrew/bin/mise` を bare `mise`（ラッパー解決）へ
- **renovate.json**: 狙撃 customManager を追加。`jdx/mise` を単一 depName として **`min_version` と `bin/mise` の版数決定2箇所（install path / install version）を1 PR で lockstep bump**
- **README.md**: セットアップを bootstrap 起点の 5 ステップへ刷新＋`更新`節を追加

## セットアップ新フロー

```
git clone → ./bin/mise install → ./bin/mise dotfiles apply → ./setup-brew.sh
```

## レビュー時の確認ポイント

- **renovate の lockstep**: 新リリースが minimum release age を通過すると、min_version・bin/mise の2行が同じ PR で一緒に上がり、常に「埋込版 ≥ min_version」が保たれる（floor 落ちが構造的に起きない）
- **生成物である bin/mise を renovate が書き換える点**: Gradle/Maven wrapper と同じパターン。install する版だけを上げ、baked baseline（`current_version`＋checksum 146–161行）は据え置く。install 版 ≠ baseline のため checksum は GitHub から都度取得され検証は保たれる（実測確認済み）。綺麗に作り直したいときだけ `mise generate bootstrap -w bin/mise` で再生成
- **狙撃 regex の誤爆なし**: 版数決定2行のみにヒットし、checksum 行・`current_version` 行には当たらないことを確認済み

## 検証済み（ローカル、brew mise 削除後）

- `mise` が PATH で `~/dotfiles/bin/mise`（2026.7.5）へ解決 → `min_version` floor を充足、`mise activate zsh` 正常生成
- `mise/config.toml` のパース、`mise dotfiles status` で `~/.config/mise` = applied（apply は冪等・既存リンク非破壊）
- bootstrap で入れた mise が `mise self-update` 可能（brew 版は拒否＝移行の動機を実証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
