### PR TITLE
refactor: tmux 起動タスクの実装スタイルを codex 基準に統一

### DIFF
--- a/mise/tasks/claude/tmux-dev
+++ b/mise/tasks/claude/tmux-dev
@@ -2,6 +2,8 @@
 #MISE description="Start tmux with Claude Code + helix preview pane"
 #MISE dir="{{cwd}}"
 
+set -euo pipefail
+
 SESSION_NAME="claude-dev"
 
 # Select repository directory via zoxide
@@ -10,16 +12,20 @@ REPO_NAME=$(basename "$TARGET_DIR")
 
 CLAUDE_CMD="mise run claude:dev"
 
-if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
-    # Switch to existing window or create new one
-    if tmux list-windows -t "$SESSION_NAME" -F '#{window_name}' | grep -q "^${REPO_NAME}$"; then
-        tmux select-window -t "$SESSION_NAME:$REPO_NAME"
-    else
-        tmux new-window -t "$SESSION_NAME" -n "$REPO_NAME" -c "$TARGET_DIR" "$CLAUDE_CMD"
-    fi
-    # Attach only if not already inside tmux
-    [ -z "$TMUX" ] && tmux attach-session -t "$SESSION_NAME"
-else
-    tmux new-session -d -s "$SESSION_NAME" -n "$REPO_NAME" -c "$TARGET_DIR" "$CLAUDE_CMD"
+open_or_attach() {
+  if [ -z "${TMUX:-}" ]; then
     tmux attach-session -t "$SESSION_NAME"
+  fi
+}
+
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+  if tmux list-windows -t "$SESSION_NAME" -F '#{window_name}' | grep -q "^${REPO_NAME}$"; then
+    tmux select-window -t "$SESSION_NAME:$REPO_NAME"
+  else
+    tmux new-window -t "$SESSION_NAME" -n "$REPO_NAME" -c "$TARGET_DIR" "$CLAUDE_CMD"
+  fi
+  open_or_attach
+else
+  tmux new-session -d -s "$SESSION_NAME" -n "$REPO_NAME" -c "$TARGET_DIR" "$CLAUDE_CMD"
+  tmux attach-session -t "$SESSION_NAME"
 fi

--- a/mise/tasks/claude/tmux-dev-wt
+++ b/mise/tasks/claude/tmux-dev-wt
@@ -2,6 +2,8 @@
 #MISE description="Start tmux with Claude Code in a worktree (parallel work)"
 #MISE dir="{{cwd}}"
 
+set -euo pipefail
+
 SESSION_NAME="claude-dev"
 
 # Select repository directory via zoxide
@@ -9,19 +11,26 @@ TARGET_DIR=$(zoxide query -i) || exit 0
 REPO_NAME=$(basename "$TARGET_DIR")
 
 # Generate random window name suffix
-WINDOW_SUFFIX="wt-$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)"
+# head が閉じると tr が SIGPIPE で死ぬため、pipefail 下でも落ちないよう || true で握る
+WINDOW_SUFFIX="wt-$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)" || true
 
 WINDOW_NAME="${REPO_NAME}-${WINDOW_SUFFIX}"
 CLAUDE_CMD="mise run claude:dev-wt"
 
-if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
-    if tmux list-windows -t "$SESSION_NAME" -F '#{window_name}' | grep -q "^${WINDOW_NAME}$"; then
-        tmux select-window -t "$SESSION_NAME:$WINDOW_NAME"
-    else
-        tmux new-window -t "$SESSION_NAME" -n "$WINDOW_NAME" -c "$TARGET_DIR" "$CLAUDE_CMD"
-    fi
-    [ -z "$TMUX" ] && tmux attach-session -t "$SESSION_NAME"
-else
-    tmux new-session -d -s "$SESSION_NAME" -n "$WINDOW_NAME" -c "$TARGET_DIR" "$CLAUDE_CMD"
+open_or_attach() {
+  if [ -z "${TMUX:-}" ]; then
     tmux attach-session -t "$SESSION_NAME"
+  fi
+}
+
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+  if tmux list-windows -t "$SESSION_NAME" -F '#{window_name}' | grep -q "^${WINDOW_NAME}$"; then
+    tmux select-window -t "$SESSION_NAME:$WINDOW_NAME"
+  else
+    tmux new-window -t "$SESSION_NAME" -n "$WINDOW_NAME" -c "$TARGET_DIR" "$CLAUDE_CMD"
+  fi
+  open_or_attach
+else
+  tmux new-session -d -s "$SESSION_NAME" -n "$WINDOW_NAME" -c "$TARGET_DIR" "$CLAUDE_CMD"
+  tmux attach-session -t "$SESSION_NAME"
 fi


### PR DESCRIPTION
## 概要

3つの tmux 起動タスク（`claude/tmux-dev` / `claude/tmux-dev-wt` / `codex/tmux-dev`）の実装スタイルが不統一だったため、最も整っていた `codex/tmux-dev` を基準に claude 側 2 ファイルを揃えた。共通ライブラリへの統合はせず、各ファイルは独立したまま。

## 変更内容

`claude/tmux-dev` と `claude/tmux-dev-wt` に対して:

- `set -euo pipefail` を追加し、堅牢性を 3 ファイルで揃える
- attach 処理を `open_or_attach()` ヘルパーに統一（従来はインラインの `[ -z "$TMUX" ] && ...`）
- インデントを 2 スペースに統一し、if/else の骨格を codex と一致させる

`codex/tmux-dev` は基準のため無変更。

## レビュー時の注意

- **`tmux-dev-wt` の乱数生成行に `|| true` を追加している**理由: `tr -dc ... < /dev/urandom | head -c 4` は head がパイプを閉じると tr が SIGPIPE(141) で死ぬ。`pipefail` 下では代入が非ゼロ終了し `set -e` で落ちるため、`|| true` で握っている（suffix の中身は取得済みなので機能影響なし）。コード内にも同旨のコメントを付与。
- **ペイン分割の配置差は意図的に維持**: claude 側は `dev-session-start.sh`（SessionStart フック）でペイン分割、codex 側はタスク内蔵。これはスタイルではなく機能設計の差のため揃えていない。

## 検証

- 3 ファイルとも `bash -n` で構文 OK
- `set -euo pipefail` 追加後、`tmux-dev-wt` の乱数行が対策込みで正常動作（`suffix=[wt-xxxx] exit=0`）することを実地確認。対策を外すと `exit=141` で落ちることも確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)