### PR TITLE
chore: [bootstrap.repos] で dotfiles リポジトリ自身を宣言管理

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ cd ~/dotfiles
 ./bin/mise bootstrap
 ```
 
-`mise bootstrap` は現行 config に対して宣言的なセットアップを順に流す1コマンドで、この repo では **`[bootstrap.packages]` の GUI アプリ・フォント（brew-cask。アプリは `/Applications`、フォントは `~/Library/Fonts`）**・**`[tools]` の CLI ツール**・**`[dotfiles]` のシンボリックリンク**を一括適用する（他の `[bootstrap.*]` セクションは未定義なので no-op）。宣言的ステップは収束するため再実行は安全で、状況は `./bin/mise bootstrap status` で確認できる。
+`mise bootstrap` は現行 config に対して宣言的なセットアップを順に流す1コマンドで、この repo では **`[bootstrap.packages]` の GUI アプリ・フォント（brew-cask。アプリは `/Applications`、フォントは `~/Library/Fonts`）**・**`[bootstrap.repos]` の dotfiles リポジトリ自身（`~/dotfiles` を `main` に追従）**・**`[tools]` の CLI ツール**・**`[dotfiles]` のシンボリックリンク**を一括適用する（他の `[bootstrap.*]` は未定義なので no-op）。宣言的ステップは収束するため再実行は安全で、状況は `./bin/mise bootstrap status` で確認できる。
 
 - `bin/mise` は初回に mise 本体を `~/.cache/mise` へ取得してから実行する（mise 未導入でも動く）。リポジトリ内で実行するため `mise/config.toml` がローカル config として読まれる。埋込版は renovate が `min_version` と lockstep で追従するため floor を下回らない（任意で最新化するなら `./bin/mise self-update`）。
 - 適用される dotfiles は `~/.zshrc` や `~/.config/*` など。mise 設定自身の `~/.config/mise` -> `~/dotfiles/mise` もここで張る。以降は新しいシェルで `~/dotfiles/bin` が PATH に入り、`mise` はこのラッパーに解決される。
+- `[bootstrap.repos]` を含むため `mise bootstrap` は `~/dotfiles` が clean であることを要求する（ローカル変更があると repos ステップで安全のため停止するので、コミット / stash してから実行する）。
 
-> 個別に実行したいときは `./bin/mise dotfiles apply`（dotfiles のみ）／ `./bin/mise install`（tools のみ）／ `./bin/mise bootstrap packages`（GUI アプリ・フォントのみ）も使える。なお `mise bootstrap` コマンドは、ラッパー `bin/mise` を生成する `mise generate bootstrap`（下記「更新」）とは別物。
+> 個別に実行したいときは `./bin/mise dotfiles apply`（dotfiles のみ）／ `./bin/mise install`（tools のみ）／ `./bin/mise bootstrap packages`（GUI アプリ・フォントのみ）／ `./bin/mise bootstrap repos`（dotfiles リポジトリのみ）も使える。なお `mise bootstrap` コマンドは、ラッパー `bin/mise` を生成する `mise generate bootstrap`（下記「更新」）とは別物。
 
 ### 3. GitHub 認証
 
@@ -49,3 +50,4 @@ GitHub App の短命トークン（8時間／[ghtkn](https://github.com/suzuki-s
 
 - **mise 本体**: renovate が `min_version` と `bin/mise` の埋込版を lockstep で追従（minimum release age 付き、同じ depName なので1 PR で一括）。日常で最新にしたいときは `mise self-update`。`bin/mise` を綺麗に作り直したいときだけ手動再生成する: `mise generate bootstrap -w bin/mise`（checksum baseline も最新化される）
 - **CLI ツール**: renovate の PR で `[tools]` と `mise.lock` を追従。手動なら `mise upgrade`
+- **dotfiles リポジトリ**: `mise bootstrap` の repos ステップが `~/dotfiles` を `main` へ追従（clean な作業ツリー時のみ。dirty なら停止）

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -64,6 +64,11 @@ GH_TOKEN = "{{ exec(command='[ -f $HOME/.gitconfig.ghtkn ] && ghtkn get 2>/dev/n
 # フォント（ghostty 主フォント）
 "brew-cask:font-hack-nerd-font" = "latest"
 
+# dotfiles リポジトリ自身。`mise bootstrap` の repos ステップで clone / 更新する（self-managing。
+# 未 clone なら取得、既にあれば ref=main に追従）。dotfiles 適用より前に走る。
+[bootstrap.repos]
+"~/dotfiles" = { url = "git@github.com:boykush/dotfiles.git", ref = "main" }
+
 [shell_alias]
 cat = "bat"
 vi = "hx"

--- a/mise/mise.lock
+++ b/mise/mise.lock
@@ -308,6 +308,41 @@ url = "https://github.com/junegunn/fzf/releases/download/v0.73.1/fzf-0.73.1-wind
 version = "1.2.0"
 backend = "aqua:lsd-rs/lsd"
 
+[tools."aqua:lsd-rs/lsd"."platforms.linux-arm64"]
+checksum = "sha256:642ecb1a763b9f790a99c83a1445c117a6813ed4edb5d498d4420423c6353eb8"
+url = "https://github.com/lsd-rs/lsd/releases/download/v1.2.0/lsd-v1.2.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/lsd-rs/lsd/releases/assets/303319949"
+
+[tools."aqua:lsd-rs/lsd"."platforms.linux-arm64-musl"]
+checksum = "sha256:642ecb1a763b9f790a99c83a1445c117a6813ed4edb5d498d4420423c6353eb8"
+url = "https://github.com/lsd-rs/lsd/releases/download/v1.2.0/lsd-v1.2.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/lsd-rs/lsd/releases/assets/303319949"
+
+[tools."aqua:lsd-rs/lsd"."platforms.linux-x64"]
+checksum = "sha256:77849da1210336534258551a581401ba19ae6b8d7b66a2a1feff148ad41e3814"
+url = "https://github.com/lsd-rs/lsd/releases/download/v1.2.0/lsd-v1.2.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/lsd-rs/lsd/releases/assets/303319745"
+
+[tools."aqua:lsd-rs/lsd"."platforms.linux-x64-musl"]
+checksum = "sha256:77849da1210336534258551a581401ba19ae6b8d7b66a2a1feff148ad41e3814"
+url = "https://github.com/lsd-rs/lsd/releases/download/v1.2.0/lsd-v1.2.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/lsd-rs/lsd/releases/assets/303319745"
+
+[tools."aqua:lsd-rs/lsd"."platforms.macos-arm64"]
+checksum = "sha256:9e34a5d392ff913302098aad0543dafa1883c531eaf229b82f086c3fca675e3e"
+url = "https://github.com/lsd-rs/lsd/releases/download/v1.2.0/lsd-v1.2.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/lsd-rs/lsd/releases/assets/303319340"
+
+[tools."aqua:lsd-rs/lsd"."platforms.macos-x64"]
+checksum = "sha256:00d3c50551b270bbdf7da97816e5ba7f5fd10294cd310165f7f8b5523e738b9c"
+url = "https://github.com/lsd-rs/lsd/releases/download/v1.2.0/lsd-v1.2.0-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/lsd-rs/lsd/releases/assets/303319774"
+
+[tools."aqua:lsd-rs/lsd"."platforms.windows-x64"]
+checksum = "sha256:a65b9f457153934a7ce1f7e0fe1c4922a95bb2822222126e4fbaa6ee9c0d78e5"
+url = "https://github.com/lsd-rs/lsd/releases/download/v1.2.0/lsd-v1.2.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/lsd-rs/lsd/releases/assets/303320206"
+
 [[tools."aqua:sharkdp/bat"]]
 version = "0.26.1"
 backend = "aqua:sharkdp/bat"


### PR DESCRIPTION
## 概要

mise の `[bootstrap.repos]` で **dotfiles リポジトリ自身**（`~/dotfiles` = boykush/dotfiles, `ref=main`）を宣言管理する。`mise bootstrap` の repos ステップで clone / 更新され、config が machine を完全に自己記述する（mise docs 推奨の self-managing パターン）。

## 変更

- `mise/config.toml`: `[bootstrap.repos]` に `~/dotfiles` を追加
- `README.md`: セットアップ説明に repos ステップ、clean 前提の注記、個別コマンド（`bootstrap repos`）、更新節を追補
- （前提コミット）`mise.lock`: `lsd` の全 platform 解決（url/checksum）を反映。`mise bootstrap` が clean な作業ツリーで動くよう、未コミット分を先にコミット

## 検証した挙動

- `mise bootstrap repos status` / `--dry-run`: `~/dotfiles` を認識。
- **安全性**: 既存 clone にローカル変更があると repos ステップは **エラーで停止**（`has local changes; commit, stash, or clean`）。勝手に checkout / reset せず作業を壊さない。`ref` の有無に関わらず同挙動。
- 順序: `mise bootstrap` は packages → **repos** → dotfiles → tools。

## 運用上の注意

- `[bootstrap.repos]` を含むため **`mise bootstrap` は `~/dotfiles` が clean であることを要求**する（dirty だと packages の後・dotfiles/tools の前で停止）。開発中（ブランチ作業・未コミット）は `mise bootstrap` を回さない運用でカバー。
- この repo は手動 clone 前提（`bin/mise` 取得のため）なので、repos は初回 clone ではなく「検証 / main 追従」として働く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
