### PR TITLE
ci: mise bootstrap を macOS で検証する GitHub Actions を追加

### DIFF
--- a/.github/workflows/mise-bootstrap.yml
+++ b/.github/workflows/mise-bootstrap.yml
@@ -50,16 +50,16 @@ jobs:
       # 本命。packages(GUIアプリ) と repos(SSH自己clone) はスキップし、
       # bin/mise の self-install → dotfiles symlink → [tools] インストールを実適用する。
       # --force-dotfiles: ランナー既存の dotfile と衝突しても置換（ephemeral なCIなので安全）。
-      # --locked: [tools] を mise.lock の事前解決URLだけで入れる（GitHub/aqua への API 解決を禁止）。
-      #           ランナー platform=macos-arm64 の解決が lock に無ければ失敗＝ロックファイルの穴を検出。
+      # インストールは config の lockfile=true により mise.lock 通りに再現される。
+      # lock の鮮度・全 platform 網羅の検証はこの workflow のスコープ外（別途 `mise lock` で担保）。
       - name: Bootstrap (dotfiles + tools)
-        run: cd "$HOME/dotfiles" && ./bin/mise bootstrap --skip packages,repos --force-dotfiles --locked
+        run: cd "$HOME/dotfiles" && ./bin/mise bootstrap --skip packages,repos --force-dotfiles
 
       # 収束確認: 適用済みなら再実行しても no-op で通る。主要 symlink と tool の実行も確認。
       - name: Verify convergence
         run: |
           cd "$HOME/dotfiles"
-          ./bin/mise bootstrap --skip packages,repos --force-dotfiles --locked
+          ./bin/mise bootstrap --skip packages,repos --force-dotfiles
           test -L "$HOME/.zshrc"
           test -L "$HOME/.config/mise"
           ./bin/mise ls

--- a/.github/workflows/mise-bootstrap.yml
+++ b/.github/workflows/mise-bootstrap.yml
@@ -1,0 +1,66 @@
+name: mise bootstrap
+
+# 新環境セットアップ（`./bin/mise bootstrap`）が壊れていないかを macOS で検証する。
+# GUI アプリ（brew-cask）と SSH 自己 clone は CI 向きでないため applied 対象から外し、
+# 実マシンで実際に走る主要部分（bin/mise の self-install → dotfiles symlink → [tools]）を
+# 実適用して収束まで確認する。
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# 既定は権限なし。ジョブに checkout 用の contents: read だけ与える。
+permissions: {}
+
+# 同一 ref の実行は最新だけ残す。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bootstrap:
+    name: bootstrap (macOS)
+    runs-on: macos-latest # Apple Silicon。mise.lock の macos-arm64 解決を使う
+    timeout-minutes: 20
+    permissions:
+      contents: read # checkout
+    env:
+      # bootstrap / dotfiles は実験的機能。config の experimental=true に加え保険で明示。
+      MISE_EXPERIMENTAL: "1"
+      # 非対話。確認プロンプトを自動 yes に。
+      MISE_YES: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false # トークンを作業ツリーに残さない（zizmor: artipacked）
+
+      # config / dotfiles の参照先は絶対パス ~/dotfiles 前提のため、
+      # チェックアウトを実マシンと同じ ~/dotfiles に配置してから実行する。
+      - name: Place repo at ~/dotfiles
+        run: cp -R "$GITHUB_WORKSPACE" "$HOME/dotfiles"
+
+      # GUIアプリ(brew-cask)は入れないが、[bootstrap.packages] が brew-cask backend で
+      # 解決できるかだけ確認する（--missing を付けないので未インストールでも exit 0。app DL なし）。
+      # ランナーには brew が同梱。cask 名の typo や backend 無効化などの設定崩れをここで検出。
+      - name: Check packages config resolves (no install)
+        run: cd "$HOME/dotfiles" && ./bin/mise bootstrap packages status
+
+      # 本命。packages(GUIアプリ) と repos(SSH自己clone) はスキップし、
+      # bin/mise の self-install → dotfiles symlink → [tools] インストールを実適用する。
+      # --force-dotfiles: ランナー既存の dotfile と衝突しても置換（ephemeral なCIなので安全）。
+      # --locked: [tools] を mise.lock の事前解決URLだけで入れる（GitHub/aqua への API 解決を禁止）。
+      #           ランナー platform=macos-arm64 の解決が lock に無ければ失敗＝ロックファイルの穴を検出。
+      - name: Bootstrap (dotfiles + tools)
+        run: cd "$HOME/dotfiles" && ./bin/mise bootstrap --skip packages,repos --force-dotfiles --locked
+
+      # 収束確認: 適用済みなら再実行しても no-op で通る。主要 symlink と tool の実行も確認。
+      - name: Verify convergence
+        run: |
+          cd "$HOME/dotfiles"
+          ./bin/mise bootstrap --skip packages,repos --force-dotfiles --locked
+          test -L "$HOME/.zshrc"
+          test -L "$HOME/.config/mise"
+          ./bin/mise ls
+          ./bin/mise exec -- jq --version


### PR DESCRIPTION
## 概要

新環境セットアップ `./bin/mise bootstrap` が壊れていないかを **macOS (`macos-latest`)** で検証する GitHub Actions を追加します。`mise test-tools` に相当する「tools の検証」だけでなく、bootstrap のフロー全体（`bin/mise` の self-install → dotfiles symlink → `[tools]`）に CI の網をかけるのが狙いです。

## やること / やらないこと

bootstrap の各ステップは CI との相性で切り分けています。

| ステップ | CI での扱い | 理由 |
|---|---|---|
| `bin/mise` self-install | ✅ 実行（＝テスト） | ラッパー自体の回帰検出 |
| `[dotfiles]` symlink | ✅ 実適用 | source 消滅・dangling を検出 |
| `[tools]` (`mise install`) | ✅ 実適用（`lockfile=true` で lock 通り） | 本命。checksum 検証付き |
| `[bootstrap.packages]` | ⚠️ `packages status` のみ | GUIアプリ(arc/claude/codex/ghostty)の DL は重く自動更新で flaky。設定解決だけ確認 |
| `[bootstrap.repos]` | ⏭️ 未実行 | `git@…` の SSH 自己 clone、CI に鍵なし |

## ワークフローの構成（`macos-latest`, 5 ステップ）

1. Checkout
2. チェックアウトを絶対パス前提の `~/dotfiles` に配置
3. `mise bootstrap packages status` — brew-cask 設定の解決のみ確認（未インストールでも exit 0、app DL なし）
4. `mise bootstrap --skip packages,repos --force-dotfiles` — 実適用
5. 収束確認 — 再実行で no-op 収束 + 主要 symlink + `mise exec -- jq --version`

## lock の扱い（スコープ外）

インストールは config の `lockfile = true` により `mise.lock` 通りに再現されます。一方で **lock の鮮度（config との同期）や全 platform 網羅の検証は、この workflow のスコープ外**です。これらは対象 platform が macOS に限られない別種の検証（`mise lock` 相当）なので、必要になったら独立したジョブとして切り出す方針とし、bootstrap ジョブ側の `--locked` 指定は入れていません（macos-arm64 だけを見る冗長チェックになるため）。

## レビュー時の補足

- この repo で回っている `zizmor` を通すため、action は SHA ピン・`persist-credentials: false`・`permissions: {}` + job 最小権限にしています。
- ローカルで検証済み: ワークフローの YAML 構文 / `packages status` が exit 0・app DL なし。
- 実際の CI 実行（apply 系）はこの PR の Actions で初めて走ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
