### PR TITLE
chore: mise の experimental 設定と dotfiles の実験的表記を削除

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -5,10 +5,9 @@
 min_version = "2026.7.5"
 
 [settings]
-experimental = true
 lockfile = true
 disable_backends = ["npm", "vfox", "asdf"]
-# dotfiles 機能（実験的）。[dotfiles] のシンボリックリンクを宣言的に管理する。
+# dotfiles 機能。[dotfiles] のシンボリックリンクを宣言的に管理する。
 # root は `mise dotfiles add` で新規ソースを配置する基準。default_mode=symlink により
 # 各エントリは既定でシンボリックリンクになる。
 dotfiles.root = "~/dotfiles"


### PR DESCRIPTION
## 概要

mise の `experimental` に関する設定・記述が古くなっていたため整理する。この config が使う機能はいずれも `experimental = true` を必要としなくなっていたため、設定ごと削除し、コメントの実験的表記も除去する。

## 変更内容

`mise/config.toml` の2箇所:
- `[settings]` から `experimental = true` を削除
- dotfiles 機能コメントの「（実験的）」を除去（`# dotfiles 機能（実験的）` → `# dotfiles 機能`）

## なぜ experimental 不要か

この config が使う全機能について、公式ドキュメント＋**インストール済み mise 2026.7.5 での実機検証**で確認:

| 機能 | 状態 |
|---|---|
| `dotfiles`（`.root` / `.default_mode` / `[dotfiles]`） | **GA**（ドキュメント上 experimental 表記なし） |
| `[bootstrap.packages]`（brew-cask）/ `[bootstrap.repos]` | **GA**（v2026.6.14「Bootstrap, end-to-end」で experimental 卒業。`min_version = 2026.7.5` はそれ以降） |
| `lockfile = true` | 元々 experimental 非依存（settings.toml 定義に experimental プロパティなし） |
| `[shell_alias]` / env の `exec()` | 標準機能 |

## 検証

`experimental` をオフ（default false）にした隔離環境に本 config をフルパースさせ、以下を実機確認:
- `unknown field` や「requires experimental」警告が出ない
- `lockfile` / `dotfiles.*` が有効なまま
- `mise bootstrap packages status` / `mise bootstrap repos status` が動作

## レビュアー向け補足

ユーザーの認識どおり dotfiles は GA 済みですが、加えて **bootstrap 系も既に GA** で、この config には experimental を要する機能が一つも残っていなかったため設定ごと削除しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)