### PR TITLE
ci: bootstrap CI から MISE_EXPERIMENTAL=1 を削除

### DIFF
--- a/.github/workflows/mise-bootstrap.yml
+++ b/.github/workflows/mise-bootstrap.yml
@@ -26,8 +26,6 @@ jobs:
     permissions:
       contents: read # checkout
     env:
-      # bootstrap / dotfiles は実験的機能。config の experimental=true に加え保険で明示。
-      MISE_EXPERIMENTAL: "1"
       # 非対話。確認プロンプトを自動 yes に。
       MISE_YES: "1"
     steps:


### PR DESCRIPTION
## 概要

mise v2026.7.4 で `mise bootstrap`(全サブコマンド)と `mise dotfiles` が experimental を卒業したため([リリースノート](https://github.com/jdx/mise/releases/tag/v2026.7.4) / [jdx/mise#10869](https://github.com/jdx/mise/pull/10869))、bootstrap CI の `MISE_EXPERIMENTAL: "1"` とそのコメントを削除する。env は `MISE_YES: "1"` のみになる。

## 背景

- コメントが指していた「config の experimental=true」は 8e3dd0c で削除済みで、記述が現状と不整合だった
- `min_version = "2026.7.5"`(≥ 2026.7.4)のため、フラグ無しでの動作は floor で保証されている
- 実マシン(フラグ無し)と CI の実行条件が揃い、stable 化された挙動そのものを CI で検証できるようになる

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)