### PR TITLE
ci: 収束検証を mise bootstrap dotfiles status --missing に置き換え

### DIFF
--- a/.github/workflows/mise-bootstrap.yml
+++ b/.github/workflows/mise-bootstrap.yml
@@ -55,13 +55,14 @@ jobs:
       - name: Bootstrap (dotfiles + tools)
         run: cd "$HOME/dotfiles" && ./bin/mise bootstrap --skip packages,repos --force-dotfiles
 
-      # 収束確認: 適用済みなら再実行しても no-op で通る。主要 symlink と tool の実行も確認。
+      # 収束確認: 適用済みなら再実行しても no-op で通る。tool の実行も確認。
       - name: Verify convergence
         run: |
           cd "$HOME/dotfiles"
           ./bin/mise bootstrap --skip packages,repos --force-dotfiles
-          # .zshrc は block-edit で管理する通常ファイル。マーカーの存在で適用を確認。
-          grep -q '>>> mise:activate >>>' "$HOME/.zshrc"
-          test -L "$HOME/.config/mise"
+          # 全 [dotfiles] エントリ（symlink / block 両モード）を機械検証する
+          # （missing / source missing / differs があれば exit 1）。config が検証の
+          # 単一真実源になり、エントリの追加・変更に CI 側の手動追随が不要になる。
+          ./bin/mise bootstrap dotfiles status --missing
           ./bin/mise ls
           ./bin/mise exec -- jq --version


### PR DESCRIPTION
## 概要

Verify convergence の個別ハードコード検証(マーカー grep + symlink `test -L`)を、mise v2026.6.14 で入った phase 単位の status([jdx/mise#10608](https://github.com/jdx/mise/pull/10608), [jdx/mise#10612](https://github.com/jdx/mise/pull/10612))に置き換える:

```yaml
./bin/mise bootstrap dotfiles status --missing
```

## 効果

- `[dotfiles]` の全エントリ(symlink / block 両モード)が **missing / source missing / differs** まで機械検証される(grep はマーカーの存在しか見ないためブロック内容の乖離を検出できなかった)
- config が検証の単一真実源になり、エントリの追加・変更のたびに CI 側へ手動追随する必要がなくなる(#148 でも grep への書き換えが発生。#159 の zshenv 廃止のようなエントリ増減にも自動追随する)

## 備考

- aggregate の `mise bootstrap status --missing` は CI では packages(GUI 未インストール)と repos(SSH clone なし)が必ず不整合になるため使えない(status サブコマンドに `--skip` は無い)。phase 単位の status が適切
- 手元(mise 2026.7.5)で動作確認済み。おまけ: #159 の activate ブロック内容変更が未適用の手元マシンでは `differs (block content differs)` が正しく検出された。旧来のマーカー grep では素通りする乖離であり、この置き換えの動機そのものの実例
- #159 マージ後の main に rebase 済み(zshenv grep の削除と競合したため解消)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)