### PR TITLE
settings: minimum_release_age = "3d" を明示

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -7,6 +7,10 @@ min_version = "2026.7.5"
 [settings]
 lockfile = true
 disable_backends = ["npm", "vfox", "asdf"]
+# 新規バージョン解決（mise upgrade 等）をリリース経過日数でフィルタし、リリース直後の版を
+# 掴まないようにする。renovate（self-hosted）の release age 3d と同値で、手動経路にも同じ
+# クールダウンを効かせる。pin 済み・インストール済みの版はそのまま有効（v2026.7.6 で担保）。
+minimum_release_age = "3d"
 # dotfiles 機能。[dotfiles] のシンボリックリンクを宣言的に管理する。
 # root は `mise dotfiles add` で新規ソースを配置する基準。default_mode=symlink により
 # 各エントリは既定でシンボリックリンクになる。


### PR DESCRIPTION
## 概要

`[settings]` に `minimum_release_age = "3d"` を追加し、手動経路の `mise upgrade` にも renovate(self-hosted、release age 3d)と同じクールダウンを効かせる。

## 背景

本リポジトリの更新は renovate による追従が基本(39be687)だが、README で案内している手動経路 `mise upgrade` にはリリース直後の版を掴まないためのガードが無かった。直近リリースで運用面が成熟したため導入する:

- v2026.7.0: 警告にリリース日時・解禁日時・実効カットオフを表示([jdx/mise#10705](https://github.com/jdx/mise/pull/10705))
- v2026.7.4: インストール済み版が条件を満たす場合の誤警告を修正([jdx/mise#10877](https://github.com/jdx/mise/pull/10877))
- v2026.7.6: インストール済み版が候補から外れないよう修正([jdx/mise#10973](https://github.com/jdx/mise/pull/10973))

## 効果・確認

- 効くのは新規バージョン解決時のみ。pin 済み・インストール済みの版はそのまま有効なので、既存の `mise install` / CI(mise.lock 通りの再現)には影響しない
- 値は issue 推奨の renovate と同値 3d
- 手元(mise 2026.7.5)で `mise settings minimum_release_age` → `3d` を確認済み

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)