### PR TITLE
chore: claude-code を http:claude バックエンドへ切替えて mise.lock に checksum を追加

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -29,6 +29,15 @@ NPM_CONFIG_REGISTRY = "https://npm.flatt.tech/"
 # 終了するため `|| true` で空にする。再評価は shell 起動/cd/設定変更時のみ。
 GH_TOKEN = "{{ exec(command='[ -f $HOME/.gitconfig.ghtkn ] && ghtkn get 2>/dev/null || true') }}"
 
+# claude shorthand をレジストリ既定（先頭 aqua）ではなく http バックエンドに固定する。
+# http:claude は Anthropic 公式の per-version manifest.json から各 platform の sha256 を取得して
+# 検証するため、mise.lock に checksum が入る（aqua レジストリ側に checksum 情報が無く、
+# lockfile=true でもこのツールだけダウンロード検証が効いていなかった）。
+# ※ [tools] に直接 "http:claude" = ... と書くのは不可。レジストリのバックエンドオプション
+# （url / checksum_url）が引き継がれず「no URL configured」で lock がスキップされる。
+[tool_alias]
+claude = "http:claude"
+
 [tools]
 # CLI tools
 "aqua:sharkdp/bat" = "0.26.1"
@@ -48,7 +57,7 @@ GH_TOKEN = "{{ exec(command='[ -f $HOME/.gitconfig.ghtkn ] && ghtkn get 2>/dev/n
 "aqua:cli/cli" = "2.94.0"
 "aqua:suzuki-shunsuke/ghtkn" = "0.3.0" # GitHub App の短命トークン発行（gh auth login の代替）
 "aqua:sxyazi/yazi" = "26.5.6"
-"aqua:anthropics/claude-code" = "2.1.195"
+claude = "2.1.195" # 実体は http:claude（上の [tool_alias] 参照）
 "aqua:tmux/tmux-builds" = "3.6a"
 
 # GUI アプリ・フォントを brew-cask backend で宣言的に管理する。`[tools]` と違い自動では入らず、

--- a/mise/mise.lock
+++ b/mise/mise.lock
@@ -60,28 +60,6 @@ url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9
 checksum = "sha256:5af00d0916f05631e3030537289eac56605e7c1733318c4d525c8e847f12496d"
 url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9.9-x86_64-pc-windows-msvc.zip"
 
-[[tools."aqua:anthropics/claude-code"]]
-version = "2.1.195"
-backend = "aqua:anthropics/claude-code"
-
-[tools."aqua:anthropics/claude-code"."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/linux-arm64/claude"
-
-[tools."aqua:anthropics/claude-code"."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/linux-arm64-musl/claude"
-
-[tools."aqua:anthropics/claude-code"."platforms.linux-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/linux-x64/claude"
-
-[tools."aqua:anthropics/claude-code"."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/linux-x64-musl/claude"
-
-[tools."aqua:anthropics/claude-code"."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/darwin-arm64/claude"
-
-[tools."aqua:anthropics/claude-code"."platforms.macos-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/darwin-x64/claude"
-
 [[tools."aqua:cli/cli"]]
 version = "2.94.0"
 backend = "aqua:cli/cli"
@@ -533,3 +511,35 @@ url = "https://github.com/tmux/tmux-builds/releases/download/v3.6a/tmux-3.6a-mac
 [tools."aqua:tmux/tmux-builds"."platforms.macos-x64"]
 checksum = "sha256:b9b12eaeba43acf5671acf3857d947525440b544185a8db34ea557199a090251"
 url = "https://github.com/tmux/tmux-builds/releases/download/v3.6a/tmux-3.6a-macos-x86_64.tar.gz"
+
+[[tools.claude]]
+version = "2.1.195"
+backend = "http:claude"
+
+[tools.claude."platforms.linux-arm64"]
+checksum = "sha256:b02279999058dc80a0e1c5d39463d1545a178615492f84139aac8d61214a7e9a"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/linux-arm64/claude"
+
+[tools.claude."platforms.linux-arm64-musl"]
+checksum = "sha256:b02279999058dc80a0e1c5d39463d1545a178615492f84139aac8d61214a7e9a"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/linux-arm64/claude"
+
+[tools.claude."platforms.linux-x64"]
+checksum = "sha256:8323e70125063147a4478b957745d835a87e5e72ffd25b838ea9a841c03e6a37"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/linux-x64/claude"
+
+[tools.claude."platforms.linux-x64-musl"]
+checksum = "sha256:8323e70125063147a4478b957745d835a87e5e72ffd25b838ea9a841c03e6a37"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/linux-x64/claude"
+
+[tools.claude."platforms.macos-arm64"]
+checksum = "sha256:8b45adad93f336ab95f33e714494b19fd3377a494eb05c122c8677bc895876ad"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/darwin-arm64/claude"
+
+[tools.claude."platforms.macos-x64"]
+checksum = "sha256:7eb8716e6d6e6a278d13158793529336290837fca457facfec656f1b1a287c60"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/darwin-x64/claude"
+
+[tools.claude."platforms.windows-x64"]
+checksum = "sha256:3ef7fb7b16e169739640fe2903ee7011cff8b43d2dbb15f9badc9b11cfad18a3"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.195/win32-x64/claude.exe"


### PR DESCRIPTION
## 概要

`mise.lock` は全ツールで sha256 checksum を記録しているが、`aqua:anthropics/claude-code` だけ aqua レジストリ側に checksum 情報が無く、`lockfile = true` でもこのツールだけダウンロード検証が効いていなかった。shorthand + `[tool_alias]` で `http:claude` バックエンド([registry/claude.toml](https://github.com/jdx/mise/blob/main/registry/claude.toml))に固定し、Anthropic 公式の per-version `manifest.json` の sha256 で検証する。

```toml
[tool_alias]
claude = "http:claude"

[tools]
claude = "2.1.195"
```

## issue からの差分

- issue 提案の `[alias]` は mise 2026.7.5 で「deprecated, use `[tool_alias]` instead」の警告が出るため、新名称の `[tool_alias]` を使用(挙動は同じ)

## mise.lock の変化

- `mise lock` 再生成で `[tools.claude]` の全 platform エントリに checksum が付与された(旧 aqua エントリの 6 platform → windows-x64 を含む 7 platform)。macos-arm64 の checksum は issue 記載の期待値と一致
- 旧 `[tools."aqua:anthropics/claude-code"]` の stale エントリは削除(ツールキーの変更は一回きり)
- 補足: linux musl 系エントリは http:claude のマッピングにより glibc ビルドと同一 URL になる(旧 aqua は別 URL)。本リポジトリの実利用は macOS のみで影響なし

## 検証(mise 2026.7.5)

- `mise install claude` 実走で `[3/3] checksum claude` の検証ステップが走り、`claude --version` → `2.1.195 (Claude Code)` を確認
- `[tools]` に直接 `"http:claude" = ...` と書く方式はレジストリのバックエンドオプションが引き継がれず lock がスキップされるため不採用(issue 記載どおり)

## renovate

mise manager は shorthand をレジストリ経由で解決するため version bump は従来どおり動く見込み。初回の renovate PR で mise.lock が正しく再生成されるかは要確認(issue 記載どおり)。

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)