### PR TITLE
feat: [bootstrap.macos.defaults] で macOS 設定を宣言管理

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -61,6 +61,21 @@ NPM_CONFIG_REGISTRY = "https://npm.flatt.tech/"
 [bootstrap.repos]
 "~/dotfiles" = { url = "git@github.com:boykush/dotfiles.git", ref = "main" }
 
+# macOS の defaults も宣言管理する。`mise bootstrap` の macos ステップで値の型に応じた
+# `defaults write`（-bool / -int 等）が適用され、`mise bootstrap macos defaults status --missing`
+# で乖離を機械検証できる。まずはキーボードリピートと Dock の最小セット（現マシンの実値）から。
+# 反映は対象プロセスの再読込後（Dock は killall Dock、キーリピートは再ログイン/アプリ再起動）。
+[bootstrap.macos.defaults.NSGlobalDomain]
+# System Settings のスライダーは real（float）で書くため、型付き比較の status が
+# differs にならないよう float で宣言する（int 宣言だと値が同じでも型不一致になる）。
+KeyRepeat = 2.0         # キーリピート速度: 最速
+InitialKeyRepeat = 15.0 # リピート開始までの遅延: 最短
+# 長押しでアクセント記号ピッカーを出さずキーリピートさせる（エディタのカーソル移動向け）
+ApplePressAndHoldEnabled = false
+
+[bootstrap.macos.defaults."com.apple.dock"]
+autohide = true
+
 [shell_alias]
 cat = "bat"
 vi = "hx"


### PR DESCRIPTION
## 概要

新マシンで手作業が残っていた macOS の defaults を `[bootstrap.macos.defaults]`(mise v2026.7.4 で stable 化)で宣言管理に乗せる。`mise bootstrap` の step 5(`macos defaults apply`)で適用され、`mise bootstrap macos defaults status --missing` で乖離を機械検証できる。

## 選定した最小セット(現マシンの実値を宣言化)

| domain | key | 値 |
|---|---|---|
| NSGlobalDomain | KeyRepeat | 2.0(最速) |
| NSGlobalDomain | InitialKeyRepeat | 15.0(最短) |
| NSGlobalDomain | ApplePressAndHoldEnabled | false(長押しでキーリピート) |
| com.apple.dock | autohide | true |

issue の例示 3 キーに加え、現マシンで意図的に設定済みだった ApplePressAndHoldEnabled(エディタのカーソル移動向け)を含めた。仕組みの導入が主目的なので、対象キーは今後この節に足していく。

## 実装メモ

- **float 宣言**: KeyRepeat 系は System Settings のスライダーが real(float)で書くため、int で宣言すると status の型付き比較が値一致でも `differs` になる(手元で確認)。float(`2.0` / `15.0`)で宣言して現マシンの格納型に合わせた
- **検証**: 手元(mise 2026.7.5)で `mise bootstrap macos defaults status --missing` が全 4 エントリ `set`・exit 0(=現マシンで no-op 収束)
- **CI**: `--skip packages,repos` のため defaults phase はランナーでも実適用される(ephemeral なので安全)。#151 マージ後、Verify convergence に `./bin/mise bootstrap macos defaults status --missing` を 1 行足すとここも機械検証できる(コンフリクト回避のため本 PR では触らない)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)