### PR TITLE
ci: 収束検証に macos defaults status --missing を追加

### DIFF
--- a/.github/workflows/mise-bootstrap.yml
+++ b/.github/workflows/mise-bootstrap.yml
@@ -62,5 +62,6 @@ jobs:
           # （missing / source missing / differs があれば exit 1）。config が検証の
           # 単一真実源になり、エントリの追加・変更に CI 側の手動追随が不要になる。
           ./bin/mise bootstrap dotfiles status --missing
+          ./bin/mise bootstrap macos defaults status --missing
           ./bin/mise ls
           ./bin/mise exec -- jq --version


### PR DESCRIPTION
## 概要

Verify convergence に #158 で導入した `[bootstrap.macos.defaults]` の機械検証を 1 行追加する:

```yaml
./bin/mise bootstrap macos defaults status --missing
```

#158 の実装メモに記載の通り、当時は #155(dotfiles status 置き換え)とのコンフリクト回避のため見送っていた。両 PR ともマージ済みのため追加する。

## 備考

- CI は `--skip packages,repos` のため defaults phase はランナーでも実適用されており(ephemeral なので安全)、apply → status で収束まで機械検証できる
- dotfiles status と同様、config(`[bootstrap.macos.defaults]`)が検証の単一真実源になり、エントリの追加・変更に CI 側の手動追随は不要
- 手元(mise 2026.7.5)で `./bin/mise bootstrap macos defaults status --missing` が全 4 エントリ `set`・exit 0 を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
