### PR TITLE
docs: brew-cask の brew 前提コメントを mise 公式仕様（Homebrew 不要）に修正

### DIFF
--- a/.github/workflows/mise-bootstrap.yml
+++ b/.github/workflows/mise-bootstrap.yml
@@ -41,7 +41,8 @@ jobs:
 
       # GUIアプリ(brew-cask)は入れないが、[bootstrap.packages] が brew-cask backend で
       # 解決できるかだけ確認する（--missing を付けないので未インストールでも exit 0。app DL なし）。
-      # ランナーには brew が同梱。cask 名の typo や backend 無効化などの設定崩れをここで検出。
+      # 解決は mise が Homebrew cask API を直接参照するため brew バイナリ不要。cask 名の typo や
+      # backend 無効化などの設定崩れをここで検出。
       - name: Check packages config resolves (no install)
         run: cd "$HOME/dotfiles" && ./bin/mise bootstrap packages status
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd ~/dotfiles
 
 - **mise 本体**: `bin/mise`（`mise generate bootstrap` 出力）で導入し、`mise self-update` で最新化。版数は renovate が `min_version` と埋込版を lockstep で追従（[更新](#更新)参照）
 - **CLI ツール**: `mise/config.toml`の`[tools]`（aqua backend、checksum 検証あり）で宣言的に管理。renovate が追従
-- **GUI アプリ**: `mise/config.toml`の`[bootstrap.packages]`（brew-cask backend）で宣言的に管理。`mise bootstrap`で`/Applications`へ導入（brew バイナリが前提）
+- **GUI アプリ**: `mise/config.toml`の`[bootstrap.packages]`（brew-cask backend）で宣言的に管理。`mise bootstrap`で`/Applications`へ導入（mise 組み込みのインストーラーが Homebrew cask API から直接取得するため brew バイナリは不要）
 - **フォント**: `mise/config.toml`の`[bootstrap.packages]`（`brew-cask:font-hack-nerd-font`）で Hack Nerd Font を `~/Library/Fonts` に導入（GUI アプリと同じ brew-cask backend）
 - **dotfiles**: `mise/config.toml`の`[dotfiles]`でシンボリックリンク（設定ファイル）とファイル内ブロック編集（`~/.zshrc` のシェル初期化）を宣言的に管理（`mise bootstrap`で適用。`mise dotfiles apply`で個別適用も可）
 - **npm**: `mise/config.toml`の`NPM_CONFIG_REGISTRY`で既定レジストリを [Takumi Guard](https://shisho.dev/docs/t/guard/quickstart/)（悪意あるパッケージのブロックプロキシ）に設定

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -50,8 +50,10 @@ NPM_CONFIG_REGISTRY = "https://npm.flatt.tech/"
 
 # GUI アプリ・フォントを brew-cask backend で宣言的に管理する。`[tools]` と違い自動では入らず、
 # `mise bootstrap` 実行時にインストールされる（アプリは /Applications、フォントは ~/Library/Fonts。
-# 内部で brew cask を叩くため brew バイナリが前提）。cask はバージョンを名前で表現し、GUI アプリは
-# 自身で自動更新するため latest 固定でよい（フォントも cask 追従で足りる）。
+# mise 組み込みのインストーラーが Homebrew cask API からメタデータを取得して直接インストールする
+# ため brew バイナリは不要。非対応 artifact の cask は brew に委譲されず明確なエラーになる）。
+# cask はバージョンを名前で表現し、GUI アプリは自身で自動更新するため latest 固定でよい
+# （フォントも cask 追従で足りる）。
 [bootstrap.packages]
 "brew-cask:arc"       = "latest"
 "brew-cask:claude"    = "latest"


### PR DESCRIPTION
## 概要

brew-cask backend について「内部で brew cask を叩くため brew バイナリが前提」と書いていたが、mise の現行仕様と食い違うため公式ドキュメント（[bootstrap/packages/brew](https://mise.jdx.dev/bootstrap/packages/brew.html)）に合わせて修正する。実際は mise 組み込みのインストーラーが Homebrew cask API からメタデータを直接取得してインストールし、ローカルの Homebrew は不要（v2026.6.6 リリースノートにも "without requiring a local Homebrew install" と明記）。非対応 artifact の cask は brew に委譲されず明確なエラーで失敗する。

- `mise/config.toml`: `[bootstrap.packages]` 直上の「brew バイナリが前提」を、組み込みインストーラー（brew 不要・非対応 artifact は明確なエラー）の説明に置換
- `README.md`: パッケージ管理節の GUI アプリ行の「brew バイナリが前提」を「brew バイナリは不要」に修正
- `.github/workflows/mise-bootstrap.yml`: status ステップの「ランナーには brew が同梱」という前提コメントを、cask API 直接参照（brew 不要）の説明に置換

### フォント（font-hack-nerd-font）について

公式 doc の対応 artifact 一覧（app / binary / pkg）に font の記載はないが、mise ソース（`src/system/packages/brew/cask.rs` の `FontArtifact` / `stage_font` / `link_font`）で font artifact 対応が実装されており、実機でも Caskroom の mise レシート（`.mise-cask.toml`。brew の `.metadata` は無し）から font-hack-nerd-font が mise 組み込みインストーラーで `~/Library/Fonts` に導入されたことを確認した。フォントにも brew は不要のため、brew 前提の注記は残さない。

コメント・ドキュメントのみの変更（`./bin/mise bootstrap packages status` で config が引き続き解決できることを確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)