### PR TITLE
chore: ~/.claude の dangling symlink を削除し誤った注記を除去

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -129,9 +129,6 @@ gst = "git status -s | awk '{print $2}' | xargs -I {} lsd -l --git --blocks git,
 "~/.config/gitui"   = "~/dotfiles/gitui"
 "~/.config/helix"   = "~/dotfiles/helix"
 # ~/.claude 配下（Claude Code。hooks はディレクトリごと）
-# 注: 旧スクリプトには skills の行もあったが、ソース ~/dotfiles/claude-code/skills が
-# 実在せず（＝旧 ln は dangling を生むだけで機能していなかった）、~/.claude/skills は
-# Claude Code 自身が管理する実ディレクトリのため dotfiles では扱わない。
 "~/.claude/settings.json"   = "~/dotfiles/claude-code/settings.json"
 "~/.claude/statusline.sh"   = "~/dotfiles/claude-code/statusline.sh"
 "~/.claude/claude-dev.json" = "~/dotfiles/claude-code/claude-dev.json"


### PR DESCRIPTION
## 概要

`~/.claude` に残っていた dangling symlink 2本を削除し、あわせて `mise/config.toml` の `[dotfiles]` にあった不正確な注記を除去する。

## 削除した symlink

どちらも `~/dotfiles/claude-code/` 配下のソースが存在せず、リンク切れのまま残っていた。

| symlink | 経緯 |
| --- | --- |
| `~/.claude/claude-tasks.json` | 廃止済み `claude-tasks` tmux セッション用の `--settings` ファイル。実体は `6d3910b` で削除、`postinstall.sh` の `ln` 行も `9775fc1` で削除済みだったが、既に張られていたリンクだけが残っていた |
| `~/.claude/claude-teams.json` | リポジトリに一度も存在しない（全履歴の blob を走査して 0 件）。`claude-teams` セッションの定義も `--teammate-mode tmux` を渡すだけでこの JSON を参照しておらず、手動 `ln` の空振りだった |

作業ツリー全体を grep しても両名への参照はなく、同種で唯一生きている `claude-dev.json` は `mise/tasks/claude/dev`・`dev-wt` から現役で参照されている。削除後、`~/.claude` に dangling symlink は残っていない。

## 注記を削除した理由

既存の注記は skills を tasks・teams と同列に「Claude Code 自身が管理する実体のため dotfiles では扱わない」と説明していたが、これは誤り。

- `~/.claude/skills` の中身は `claude-automation-recommender` / `claude-md-improver` / `skill-creator` の**自作 SKILL.md** で、Claude Code 管理下のものではなく dotfiles 管理の候補そのもの。ソースは `~/dotfiles/claude-code/` にスコープが切られているので置き場所の衝突もない。旧 `ln` が機能していなかったのは**ソースを作っていなかった**からで、除外の根拠にはならない
- `~/.claude/tasks`（UUID 名）・`~/.claude/teams`（案件別）はセッション実行時状態で、そもそも宣言対象にならない

本来やるべきことを「扱わない」と断定して妨げる内容だったため、注記自体を削除した。

## レビュー観点

- `mise config get -f mise/config.toml dotfiles` でパースと `[dotfiles]` の内容が変わらないことを確認済み（両 JSON は元々未宣言）
- symlink の削除は `~/.claude` 配下の実行であり、この diff には含まれない

## フォローアップ（本 PR 対象外）

グローバル skills を `~/dotfiles/claude-code/skills` に実体を置いて `[dotfiles]` に宣言する件は、別途検討の余地あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)