### PR TITLE
Label mise automerge PRs so the approver App can act

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,11 +9,14 @@
   ],
   "packageRules": [
     {
-      "description": "mise の [tools] で管理する CLI ツール更新を、必須 CI の成功後に自動マージする。mise 本体は custom.regex manager で管理しているため対象外。",
+      "description": "mise の [tools] で管理する CLI ツール更新を、必須 CI の成功後に自動マージする。mise 本体は custom.regex manager で管理しているため対象外。addLabels は automerge と対で必須: このリポジトリは承認レビュー1件を要求し、Renovate は自分の PR を承認できない。代わりに承認する renovate-runner の approve-bot-prs ワークフローが automerge ラベルで対象を絞るため、ラベルが無いと承認が来ず automerge が永久に待つ。",
       "matchManagers": [
         "mise"
       ],
-      "automerge": true
+      "automerge": true,
+      "addLabels": [
+        "automerge"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## 背景

`renovate.json` の mise ルールは `automerge: true` を持つ一方で `addLabels: ["automerge"]` を欠いていました。

このリポジトリの ruleset は承認レビュー1件を必須にしており、Renovate は自分の PR を承認できません。代わりに承認するのは `renovate-runner` の [`approve-bot-prs.yml`](https://github.com/boykush/renovate-runner/blob/main/.github/workflows/approve-bot-prs.yml) ですが、対象の絞り込みは `--label automerge` だけです。

```
gh search prs --owner "$OWNER" --author "$PR_AUTHOR" \
  --state open --label automerge --limit 100
```

そのため、ラベルの付かない mise の `[tools]` 更新 PR は **automerge が有効なまま、来ることのない承認を永久に待ち続けます**。同ワークフローのコメントもこの不変条件を明示しています。

> The label is set by the same packageRules entry that turns automerge on (config.js), so an approval can never outrun the automerge decision.

`renovate-runner/config.js` の 2 つのルールはいずれも `automerge: true` と `addLabels: ['automerge']` を対で持っており、本 PR はリポジトリ側のルールをその規約に揃えるものです。

## 変更

mise ルールに `addLabels: ["automerge"]` を追加し、対で必須である理由を `description` に残しました。

## 確認

- `renovate-config-validator` (renovate 43.232.0) で検証済み — `Config validated successfully`
- `automerge` ラベルは本リポジトリに既存のため、追加設定は不要

## 備考

現時点で影響を受けている PR はありません。[#179](https://github.com/boykush/dotfiles/pull/179) は `jdx/mise` 本体（`custom.regex` manager）で、このルールの対象外です。次の `[tools]` 更新から効きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
