### PR TITLE
fix: Scraps MCP をどのディレクトリからでも繋がるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ cd ~/dotfiles
 
 ## AI MCP サーバー
 
-Scraps MCP は `mise run --quiet --raw scraps:mcp` を共通の起動入口にする。対象 Scraps project は task 起動時だけ `SCRAPS_PROJECT_PATH` で `~/dotfiles/wiki/scraps` に固定し、この repo の `[bootstrap.repos]` が `boykush/wiki` を dotfiles 配下へ clone / 更新する。
+Scraps MCP は `mise run --quiet --raw scraps:mcp` を共通の起動入口にする。対象 Scraps project は task 起動時に `SCRAPS_DIRECTORY` で `~/dotfiles/wiki/scraps` に固定し（呼び出し元の env は継がない。他の Scraps project 内から起動しても同じ wiki を指すため）、この repo の `[bootstrap.repos]` が `boykush/wiki` を dotfiles 配下へ clone / 更新する。
 
-各 AI セッションからの参照はクライアント側の config に置く。Codex は `mise dotfiles apply` が `~/.codex/config.toml` へ `[mcp_servers.scraps]` ブロックを適用する。Claude Code は `~/.mcp.json` を `claude-code/mcp.json` へ symlink し、ホーム配下のセッションから `.mcp.json` project config として参照させる。
+各 AI セッションからの参照はクライアント側の config に置く。Codex は `mise dotfiles apply` が `~/.codex/config.toml` へ `[mcp_servers.scraps]` ブロックを適用する。Claude Code は `~/.mcp.json` を `claude-code/mcp.json` へ symlink する。Claude Code は cwd から親を遡って `.mcp.json` を集める（複数あればマージ）ので、ホーム配下のセッションならどのディレクトリからでも拾う。ただし `.mcp.json` 由来のサーバーは project ごとに承認プロンプトが出るため、`claude-code/settings.json` の `enabledMcpjsonServers` で `scraps` だけを事前承認する（`enableAllProjectMcpServers` は clone してきた repo の `.mcp.json` まで無条件に通すので使わない）。
 
 エージェントがいつ wiki を引くかは [agents/AGENTS.md](agents/AGENTS.md) の「私のナレッジ（Scraps wiki）を引く」に書いてある。
 

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -22,6 +22,7 @@
       }
     ]
   },
+  "enabledMcpjsonServers": ["scraps"],
   "effortLevel": "max",
   "autoMemoryEnabled": false,
   "skipWorkflowUsageWarning": true,

--- a/mise/tasks/scraps/mcp
+++ b/mise/tasks/scraps/mcp
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
-export SCRAPS_PROJECT_PATH="${SCRAPS_PROJECT_PATH:-$HOME/dotfiles/wiki/scraps}"
+# scraps が読むのは SCRAPS_DIRECTORY（= -C）。呼び出し元の env を継がず固定するのは、
+# どのディレクトリから起動しても同じ個人 wiki を指すサーバーにするため。
+export SCRAPS_DIRECTORY="$HOME/dotfiles/wiki/scraps"
 
 exec scraps mcp serve


### PR DESCRIPTION
## Summary

Scraps MCP が `~/dotfiles/wiki` 配下以外のセッションから使えなかったのを直す。原因は2つ。

**1. 起動 task の環境変数名が違っていた（本丸）**

`mise/tasks/scraps/mcp` は `SCRAPS_PROJECT_PATH` を export していたが、scraps が読むのは `SCRAPS_DIRECTORY`（= `-C`）。

```
Options:
  -C, --directory <DIR>  ... [env: SCRAPS_DIRECTORY=]
```

wiki パスが一切渡らず、scraps は cwd（`#MISE dir="{{config_root}}"` = `~/dotfiles/mise`）にフォールバックして `Failed to load .scraps.toml` で起動時に落ちていた。`~/dotfiles/wiki` 配下のセッションだけ `wiki/mise.toml` の `[env] SCRAPS_DIRECTORY` を偶然継承して動いていたのが「他ディレクトリからだと動かない」の正体。

変数名を直した上で、`${VAR:-...}` のフォールバックは外して固定にした。共有サーバーが起動元ディレクトリで指す先を変えるのは、まさに今回の症状の温床なので。

**2. project ごとの承認プロンプトが残る**

`.mcp.json` 由来のサーバーは project ごとに承認が要り、新しいディレクトリでは毎回 `⏸ Pending approval` になる（#180 の Note で認識されていた挙動）。`enabledMcpjsonServers` で user scope から `scraps` だけ事前承認して解消する。

`enableAllProjectMcpServers` は clone してきた repo の `.mcp.json` まで無条件に通すので採らなかった。

## Validation

修正後の task + 設定で、無関係なディレクトリ（`/private/tmp` 配下、`SCRAPS_DIRECTORY` 未設定）から承認プロンプトなしで接続できることを確認。

```
scraps: ... - ✔ Connected
tools: ['get_scrap', 'list_tags', 'lookup_scrap_backlinks',
        'lookup_scrap_links', 'lookup_tag_backlinks', 'search_scraps']
```

- `claude mcp list` → `✔ Connected`
- MCP `tools/list` → scraps の6ツールが揃う
- `python3 -m json.tool claude-code/settings.json` / `bash -n mise/tasks/scraps/mcp`

## Notes for reviewer

- README の「ホーム配下のセッションから参照させる」という前提自体は正しかった。Claude Code は cwd から親を遡って `.mcp.json` を集める（git root も越え、複数あればマージ）ことを実測で確認済み。ただし `$HOME` の外で起動したセッションは拾えない点は変わらないので、承認の話とあわせて記述を実態に合わせた。
- `mcpServers` を `settings.json` に書く経路も試したが、このキーは settings のスキーマに無く効かなかった（`claude mcp list` に出ない）。user scope で宣言的に扱えるのは承認側の `enabledMcpjsonServers` だけ。
- 反映は main マージ後に `~/dotfiles` で pull すれば足りる（`settings.json` も `~/.config/mise` も symlink 経由のため `mise dotfiles apply` は不要）。その後セッションの再起動が要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)