### PR TITLE
chore: mise の vfox backend を許容する

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -6,7 +6,11 @@ min_version = "2026.8.3"
 
 [settings]
 lockfile = true
-disable_backends = ["npm", "vfox", "asdf"]
+# aqua に無いツールを入れる経路として vfox を許容する。mise 公式が推奨する plugin system で、
+# tool plugin は lockfile と attestation 検証（GitHub artifact attestations / cosign /
+# SLSA provenance）に対応する。ただし plugin 本体は Lua スクリプトとして実行されるため、
+# 実際に足すときは plugin の出所を確認する。
+disable_backends = ["npm", "asdf"]
 # 新規バージョン解決（mise upgrade 等）をリリース経過日数でフィルタし、リリース直後の版を
 # 掴まないようにする。renovate（self-hosted）の release age 3d と同値で、手動経路にも同じ
 # クールダウンを効かせる。pin 済み・インストール済みの版はそのまま有効（v2026.7.6 で担保）。


### PR DESCRIPTION
## 概要

`disable_backends` から `vfox` を外し、aqua に無いツールを入れる経路を確保する。`npm` / `asdf` は無効のまま。

```diff
-disable_backends = ["npm", "vfox", "asdf"]
+disable_backends = ["npm", "asdf"]
```

## なぜ

vfox は mise 公式が推奨する plugin system（Windows では既定 backend）で、tool plugin は lockfile と attestation 検証（GitHub artifact attestations / cosign / SLSA provenance）に対応する。aqua に無いツール（JVM 系や `android-sdk` など）を入れたいときの逃げ道がこれで確保できる。

トレードオフとして、vfox plugin の本体は Lua スクリプトで install 時に mise がそれを実行するため、aqua のチェックサム検証で固めてきた既存方針と比べると plugin の出所への信頼が前提になる。その旨は config のコメントに残した。

## 確認したこと

現行 mise 2026.8.3 に本 config をローカル config として読ませて実機確認した。

- `mise settings get disable_backends` -> `["npm", "asdf"]`
- `mise registry` の vfox エントリが **0 -> 58 件**（例: `gradle`, `clojure`, `groovy`, `android-sdk`, `clickhouse`）。以前 0 件だったのは disable された backend が registry 出力ごと落ちていたため
- `experimental` は **false のまま**で警告なし。vfox backend は experimental を要求しない（現行 mise で experimental を要求するのは `mise oci` / age 暗号化 / workspace project graph など）
- `mise ls --current` で既存ツールは全て `aqua:` / `github:` の明示 backend のまま。`[tools]` は全部 backend 明示なので解決先は変わらず、`mise.lock` にも差分なし

## 補足

現時点で vfox を使うツールは `[tools]` にまだ無く、この PR は経路を開けるだけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)